### PR TITLE
Capture Message-Id from response

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -70,11 +70,13 @@ class SESBackend(BaseEmailBackend):
             num_sent = 0
             for message in email_messages:
                 try:
-                    self.connection.send_raw_email(
+                    response = self.connection.send_raw_email(
                         source=message.from_email,
                         destinations=message.recipients(),
                         raw_message=message.message().as_string(),
                     )
+                    send_result = response['SendRawEmailResponse']['SendRawEmailResult']
+                    message.extra_headers['Message-Id'] = send_result['MessageId']
                     num_sent += 1
                 except SESConnection.ResponseError:
                     if not self.fail_silently:


### PR DESCRIPTION
Hi hmarr,
thanks for saving us the time of building this email backend!  I found myself needing the Message-Id header assigned to an email by amazon, but django wants send_messages to return an int.  This change grabs the id from SendRawEmailResult and stuffs it into message.extra_headers, which can be read after sending is complete.  Let me know what you think!
