### PR TITLE
Extending npenteado's idea for using extra_headers - capture error data as well

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -1,8 +1,6 @@
 from django.core.mail.backends.base import BaseEmailBackend
 from django.conf import settings
 
-import threading
-
 from boto.ses import SESConnection
 
 
@@ -72,15 +70,17 @@ class SESBackend(BaseEmailBackend):
                     destinations=message.recipients(),
                     raw_message=message.message().as_string(),
                 )
-                send_response = response['SendRawEmailResponse']
-                send_result = send_response['SendRawEmailResult']
-                message.extra_headers['Message-Id'] = send_result['MessageId']
-
+                message.extra_headers['status'] = 200
+                message.extra_headers['message_id'] = response['SendRawEmailResponse']['SendRawEmailResult']['MessageId']
+                message.extra_headers['request_id'] = response['SendRawEmailResponse']['ResponseMetadata']['RequestId']
                 num_sent += 1
-            except SESConnection.ResponseError:
+            except SESConnection.ResponseError, err:
+                # Store failure information so you can post process it if required
+                error_keys = ['status', 'reason', 'body', 'request_id', 'error_code', 'error_message']
+                for key in error_keys:
+                    message.extra_headers[key] = getattr(err, key, None)
                 if not self.fail_silently:
                     raise
-                pass
 
         if new_conn_created:
             self.close()


### PR DESCRIPTION
Hi,

I'm using this so I can auto unsubscribe any users that have undeliverable email address - as happens over time. Also, I could use it if you hit throttling issues or capture any messages you want to send when the service is down.

Also, I changed the key of Message-Id to message_id to keep it inline with the other keys formatting, you may want to keep the old format or warn @npenteado of a change.

Cheers,

Ross
