### PR TITLE
Fixing bug with DefaultHost

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -19,7 +19,9 @@ class SESBackend(BaseEmailBackend):
         self._access_key_id = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
         self._access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
         self._api_endpoint = getattr(settings, 'AWS_SES_API_HOST',
-                                     SESConnection.DefaultHost)
+                                     '%s.%s' % (
+                                        SESConnection.DefaultRegionName,
+                                        SESConnection.DefaultRegionEndpoint))
 
         self.connection = None
 

--- a/django_ses/management/commands/ses_email_address.py
+++ b/django_ses/management/commands/ses_email_address.py
@@ -32,7 +32,9 @@ class Command(BaseCommand):
         access_key_id = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
         access_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
         api_endpoint = getattr(settings, 'AWS_SES_API_HOST',
-                                     SESConnection.DefaultHost)
+                                     '%s.%s' % (
+                                        SESConnection.DefaultRegionName,
+                                        SESConnection.DefaultRegionEndpoint))
         
         connection = SESConnection(
                 aws_access_key_id=access_key_id,

--- a/django_ses/views.py
+++ b/django_ses/views.py
@@ -79,7 +79,9 @@ def dashboard(request):
     ses_conn = SESConnection(
         aws_access_key_id=getattr(settings, 'AWS_ACCESS_KEY_ID', None),
         aws_secret_access_key=getattr(settings, 'AWS_SECRET_ACCESS_KEY', None),
-        host=getattr(settings, 'AWS_SES_API_HOST', SESConnection.DefaultHost),
+        host=getattr(settings, 'AWS_SES_API_HOST', '%s.%s' % (
+                        SESConnection.DefaultRegionName,
+                        SESConnection.DefaultRegionEndpoint)),
     )
 
     quota_dict = ses_conn.get_send_quota()


### PR DESCRIPTION
SESConnection.DefaultHost was split into 2 vars.

https://github.com/boto/boto/blob/3437d7e9e42179f67e6e39da4be69d229f0ee47a/boto/ses/connection.py#L36
