### PR TITLE
Pre-Python 2.7 compatibility fix for rate throttling

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -139,7 +139,9 @@ class SESBackend(BaseEmailBackend):
                 # half of the allowed rate.
                 if len(new_send_times) > rate_limit * window * self._throttle:
                     # Sleep the remainder of the window period.
-                    delay = window - (now - new_send_times[0]).total_seconds()
+                    delta = now - new_send_times[0]
+                    total_seconds = (delta.microseconds + (delta.seconds + delta.days * 24 * 3600) * 10**6) / 10**6
+                    delay = window - total_seconds
                     if delay > 0:
                         sleep(delay)
 


### PR DESCRIPTION
do timedelta.total_seconds calculation instead of using Python 2.7 shortcut method in order to be compatible with pre-Python 2.7
