### PR TITLE
add spec file and Makefile to build RPMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
+TARBALL := $(shell python setup.py --name)-$(shell python setup.py --version).tar.gz
+
+dist/$(TARBALL):
+	python setup.py sdist
+
+$(TARBALL): dist/$(TARBALL)
+	cp dist/$(TARBALL) .
+
 clean:
 	rm -rf noarch/ BUILDROOT/
+	rm -f *.tar.gz
 
 distclean: clean
 	rm -f *.rpm
+	rm -rf dist/
 
-rpm:
+rpm: $(TARBALL)
 	rpmbuild --define "_topdir %(pwd)" \
 	--define "_builddir /tmp" \
 	--define "_rpmdir %{_topdir}" \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+clean:
+	rm -rf noarch/ BUILDROOT/
+
+distclean: clean
+	rm -f *.rpm
+
+rpm:
+	rpmbuild --define "_topdir %(pwd)" \
+	--define "_builddir /tmp" \
+	--define "_rpmdir %{_topdir}" \
+	--define "_srcrpmdir %{_topdir}" \
+	--define "_specdir %{_topdir}" \
+	--define "_sourcedir %{_topdir}" \
+	-ba django-ses.spec
+
+	mv noarch/*.rpm .
+
+rpm-test:
+	rpmlint -i *.rpm *.spec

--- a/django-ses.spec
+++ b/django-ses.spec
@@ -1,0 +1,62 @@
+%{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
+%{!?pyver: %define pyver %(%{__python} -c "import sys ; print sys.version[:3]")}
+
+Name:           %(%{__python} setup.py --name)
+Version:        %(%{__python} setup.py --version)
+Release:        1%{?dist}
+Summary:        %(%{__python} setup.py --description)
+
+Group:          Development/Libraries
+License:        %(%{__python} setup.py --license)
+URL:            %(%{__python} setup.py --url)
+Source0:        http://pypi.python.org/packages/source/d/django-ses/%{name}-%{version}.tar.gz
+
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+BuildArch:      noarch
+BuildRequires:  python-devel
+
+# NB: update this when updating setup.py
+Requires:       Django
+Requires:       python-boto >= 2.1.0
+
+
+%description
+%(%{__python} setup.py --description)
+
+%prep
+%setup -q
+
+%build
+%{__python} setup.py build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%{__python} setup.py install --skip-build --root $RPM_BUILD_ROOT
+
+mkdir -p %{buildroot}/%{_docdir}/%{name}-%{version}
+install -m 0644 README.rst %{buildroot}/%{_docdir}/%{name}-%{version}
+install -m 0644 LICENSE %{buildroot}/%{_docdir}/%{name}-%{version}
+cp -r example/ %{buildroot}/%{_docdir}/%{name}-%{version}
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
+%files
+%defattr(-,root,root,-)
+%doc %{_docdir}/%{name}-%{version}/LICENSE
+%doc %{_docdir}/%{name}-%{version}/README.rst
+%{_docdir}/%{name}-%{version}/example/*
+%{python_sitelib}/django_ses/*
+%{python_sitelib}/example/*
+
+# Leaving these since people may want to rebuild on older dists
+%if 0%{?fedora} >= 9 || 0%{?rhel} >= 6
+    %{python_sitelib}/*.egg-info
+%endif
+
+%changelog
+
+* Fri Jun 08 2012 Alexander Todorov <atodorov@nospam.otb.bg> - 0.5.0-1
+- initial build


### PR DESCRIPTION
Hi,
here's a .spec file and a Makefile to help build RPMs for those like me, who don't like to install from PyPI directly.

In the PWD ensure you have the django-ses-$VERSION.tar.gz file and run make rpm. The resulting RPMs will be in the current directory.

I've tested the resulting RPM on RHEL6 and it appears to be working correctly.

NOTE: Since latest stable is 0.4.1 and `setup.py` in Git is at 0.5.0 you have to either edit `setup.py` to match the version of the tarball or checkout 0.4.1 from git. 

NOTE2: This is unrelated but is visible while doing the packaging. The `example/` directory is installed under `/usr/lib/python-x.y/site-packages/example` which is very likely to conflict with other packages. In the RPM I place it under `/usr/share/doc/django-ses-x.y/example` but can't remove it from the Python `site-packages` dir. `setup.py` needs a patch to handle this properly.