### PR TITLE
 Make sure numerical types are converted #61

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -141,7 +141,7 @@ class SESBackend(BaseEmailBackend):
                 # Since I'm not sure how Amazon determines at exactly what
                 # point to throttle, better be safe than sorry and let in, say,
                 # half of the allowed rate.
-                if len(new_send_times) > rate_limit * window * self._throttle:
+                if len(new_send_times) > float(rate_limit) * float(window) * float(self._throttle):
                     # Sleep the remainder of the window period.
                     delta = now - new_send_times[0]
                     total_seconds = (delta.microseconds + (delta.seconds +


### PR DESCRIPTION
You get the error below in Python 2.7 due to one of the values being evaluated as a string.
TypeError: can't multiply sequence by non-int of type 'float'

To resolve make make them all of type float.
