### PR TITLE
Fix DKIM signing on python 3

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -153,11 +153,16 @@ class SESBackend(BaseEmailBackend):
                 recent_send_times.append(now)
                 # end of throttling
 
+            msg = message.message()
+            if hasattr(msg, 'as_bytes'):
+                msg_bytes = msg.as_bytes()
+            else:  # fallback for older django versions
+                msg_bytes = msg.as_string()
             try:
                 response = self.connection.send_raw_email(
                     source=source or message.from_email,
                     destinations=message.recipients(),
-                    raw_message=dkim_sign(message.message().as_string(),
+                    raw_message=dkim_sign(msg_bytes,
                                           dkim_key=self.dkim_key,
                                           dkim_domain=self.dkim_domain,
                                           dkim_selector=self.dkim_selector,


### PR DESCRIPTION
as_bytes (added in Django 1.7) is an alias to as_text on python 2, but
dkim.sign() needs proper bytes on Python 3.