### PR TITLE
Fix url warnings for django 1.10

### DIFF
--- a/django_ses/tests/test_urls.py
+++ b/django_ses/tests/test_urls.py
@@ -4,8 +4,10 @@ except ImportError:
     # Fall back to the old, pre-1.6 style
     from django.conf.urls.defaults import patterns, url
 
-urlpatterns = patterns('django_ses.views',
-    url(r'^dashboard/$', 'dashboard', name='django_ses_stats'),
-    url(r'^bounce/$', 'handle_bounce', name='django_ses_bounce'),
+from django_ses.views import dashboard, handle_bounce
+
+urlpatterns = [
+    url(r'^dashboard/$', dashboard, name='django_ses_stats'),
+    url(r'^bounce/$', handle_bounce, name='django_ses_bounce'),
     #url(r'^complaint/$', 'handle_complaint', name='django_ses_complaint'),
-)
+]

--- a/django_ses/urls.py
+++ b/django_ses/urls.py
@@ -1,8 +1,10 @@
 try:
     from django.conf.urls import patterns, url
-except ImportError: # django < 1.4
+except ImportError:  # django < 1.4
     from django.conf.urls.defaults import patterns, url
 
-urlpatterns = patterns('django_ses.views',
-    url(r'^$', 'dashboard', name='django_ses_stats'),
-)
+from django_ses.views import dashboard
+
+urlpatterns = [
+    url(r'^$', dashboard, name='django_ses_stats'),
+]


### PR DESCRIPTION
django-ses was emitting some Django 1.10 warnings:

```
/usr/local/lib/python2.7/dist-packages/django_ses/urls.py:7: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got dashboard). Pass the callable instead.
  url(r'^$', 'dashboard', name='django_ses_stats'),

/usr/local/lib/python2.7/dist-packages/django_ses/urls.py:7: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^$', 'dashboard', name='django_ses_stats'),
```

@pcraciunoiu 

Related: https://github.com/django-ses/django-ses/pull/93