### PR TITLE
Fix import errors for Django 1.10 since patterns no longer exists

### DIFF
--- a/django_ses/tests/test_urls.py
+++ b/django_ses/tests/test_urls.py
@@ -1,8 +1,8 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:
     # Fall back to the old, pre-1.6 style
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
 from django_ses.views import dashboard, handle_bounce
 

--- a/django_ses/urls.py
+++ b/django_ses/urls.py
@@ -1,7 +1,7 @@
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:  # django < 1.4
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
 from django_ses.views import dashboard
 


### PR DESCRIPTION
@pcraciunoiu This didn't show up as a warning, but we don't use patterns anyways and it no longer exists in 1.10.