### PR TITLE
Add support for proxy host and port

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,6 +279,12 @@ Full List of Settings
   Instruct Amazon SES to forward bounced emails and complaints to this email.
   For more information please refer to http://aws.amazon.com/ses/faqs/#38
 
+``AWS_SES_PROXY``
+  Optional. Use this address as a proxy while connecting to Amazon SES.
+
+``AWS_SES_PROXY_PORT``
+  Optional. Use this port for proxy connections while connecting to Amazon SES.
+
 ``TIME_ZONE``
   Default Django setting, optionally set this. Details:
   https://docs.djangoproject.com/en/dev/ref/settings/#time-zone

--- a/README.rst
+++ b/README.rst
@@ -285,6 +285,13 @@ Full List of Settings
 ``AWS_SES_PROXY_PORT``
   Optional. Use this port for proxy connections while connecting to Amazon SES.
 
+``AWS_SES_PROXY_USER``
+  Optional. Use this user when setting up proxy connections while connecting to Amazon SES.
+
+``AWS_SES_PROXY_PASS``
+  Optional. Use this password when setting up proxy connections while connecting to Amazon SES.
+
+
 ``TIME_ZONE``
   Default Django setting, optionally set this. Details:
   https://docs.djangoproject.com/en/dev/ref/settings/#time-zone

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -80,6 +80,7 @@ class SESBackend(BaseEmailBackend):
                 aws_secret_access_key=self._access_key,
                 region=self._region,
                 proxy=self._proxy,
+                proxy_port=self._proxy_port,
             )
         except:
             if not self.fail_silently:

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -48,7 +48,7 @@ class SESBackend(BaseEmailBackend):
                  aws_secret_key=None, aws_region_name=None,
                  aws_region_endpoint=None, aws_auto_throttle=None,
                  dkim_domain=None, dkim_key=None, dkim_selector=None,
-                 dkim_headers=None, **kwargs):
+                 dkim_headers=None, proxy=None, proxy_port=None, **kwargs):
 
         super(SESBackend, self).__init__(fail_silently=fail_silently, **kwargs)
         self._access_key_id = aws_access_key or settings.ACCESS_KEY
@@ -57,6 +57,8 @@ class SESBackend(BaseEmailBackend):
             name=aws_region_name or settings.AWS_SES_REGION_NAME,
             endpoint=aws_region_endpoint or settings.AWS_SES_REGION_ENDPOINT)
         self._throttle = aws_auto_throttle or settings.AWS_SES_AUTO_THROTTLE
+        self._proxy = proxy or settings.AWS_SES_PROXY
+        self._proxy_port = proxy_port or settings.AWS_SES_PROXY_PORT
 
         self.dkim_domain = dkim_domain or settings.DKIM_DOMAIN
         self.dkim_key = dkim_key or settings.DKIM_PRIVATE_KEY
@@ -77,6 +79,7 @@ class SESBackend(BaseEmailBackend):
                 aws_access_key_id=self._access_key_id,
                 aws_secret_access_key=self._access_key,
                 region=self._region,
+                proxy=self._proxy,
             )
         except:
             if not self.fail_silently:

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -48,7 +48,8 @@ class SESBackend(BaseEmailBackend):
                  aws_secret_key=None, aws_region_name=None,
                  aws_region_endpoint=None, aws_auto_throttle=None,
                  dkim_domain=None, dkim_key=None, dkim_selector=None,
-                 dkim_headers=None, proxy=None, proxy_port=None, **kwargs):
+                 dkim_headers=None, proxy=None, proxy_port=None,
+                 proxy_user=None, proxy_pass=None, **kwargs):
 
         super(SESBackend, self).__init__(fail_silently=fail_silently, **kwargs)
         self._access_key_id = aws_access_key or settings.ACCESS_KEY
@@ -59,6 +60,8 @@ class SESBackend(BaseEmailBackend):
         self._throttle = aws_auto_throttle or settings.AWS_SES_AUTO_THROTTLE
         self._proxy = proxy or settings.AWS_SES_PROXY
         self._proxy_port = proxy_port or settings.AWS_SES_PROXY_PORT
+        self._proxy_user = proxy_user or settings.AWS_SES_PROXY_USER
+        self._proxy_pass = proxy_pass or settings.AWS_SES_PROXY_PASS
 
         self.dkim_domain = dkim_domain or settings.DKIM_DOMAIN
         self.dkim_key = dkim_key or settings.DKIM_PRIVATE_KEY
@@ -81,6 +84,8 @@ class SESBackend(BaseEmailBackend):
                 region=self._region,
                 proxy=self._proxy,
                 proxy_port=self._proxy_port,
+                proxy_user=self._proxy_user,
+                proxy_pass=self._proxy_pass,
             )
         except:
             if not self.fail_silently:

--- a/django_ses/management/commands/get_ses_statistics.py
+++ b/django_ses/management/commands/get_ses_statistics.py
@@ -32,6 +32,8 @@ class Command(BaseCommand):
         connection = SESConnection(
             aws_access_key_id=settings.ACCESS_KEY,
             aws_secret_access_key=settings.SECRET_KEY,
+            proxy=settings.AWS_SES_PROXY,
+            proxy_port=settings.AWS_SES_PROXY_PORT,
         )
         stats = connection.get_send_statistics()
         data_points = stats_to_list(stats, localize=False)

--- a/django_ses/management/commands/get_ses_statistics.py
+++ b/django_ses/management/commands/get_ses_statistics.py
@@ -34,6 +34,8 @@ class Command(BaseCommand):
             aws_secret_access_key=settings.SECRET_KEY,
             proxy=settings.AWS_SES_PROXY,
             proxy_port=settings.AWS_SES_PROXY_PORT,
+            proxy_user=settings.AWS_SES_PROXY_USER,
+            proxy_pass=settings.AWS_SES_PROXY_PASS,
         )
         stats = connection.get_send_statistics()
         data_points = stats_to_list(stats, localize=False)

--- a/django_ses/management/commands/ses_email_address.py
+++ b/django_ses/management/commands/ses_email_address.py
@@ -62,11 +62,16 @@ class Command(BaseCommand):
         region = RegionInfo(
             name=settings.AWS_SES_REGION_NAME,
             endpoint=settings.AWS_SES_REGION_ENDPOINT)
+        proxy = settings.AWS_SES_PROXY
+        proxy_port = settings.AWS_SES_PROXY_PORT
 
         connection = SESConnection(
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=access_key,
-                region=region)
+                region=region,
+                proxy=proxy,
+                proxy_port=proxy_port,
+        )
 
         if add_email:
             if verbosity != '0':

--- a/django_ses/management/commands/ses_email_address.py
+++ b/django_ses/management/commands/ses_email_address.py
@@ -64,6 +64,9 @@ class Command(BaseCommand):
             endpoint=settings.AWS_SES_REGION_ENDPOINT)
         proxy = settings.AWS_SES_PROXY
         proxy_port = settings.AWS_SES_PROXY_PORT
+        proxy_user = settings.AWS_SES_PROXY_USER
+        proxy_pass = settings.AWS_SES_PROXY_PASS
+
 
         connection = SESConnection(
                 aws_access_key_id=access_key_id,
@@ -71,6 +74,8 @@ class Command(BaseCommand):
                 region=region,
                 proxy=proxy,
                 proxy_port=proxy_port,
+                proxy_user=proxy_user,
+                proxy_pass=proxy_pass,
         )
 
         if add_email:

--- a/django_ses/settings.py
+++ b/django_ses/settings.py
@@ -19,6 +19,8 @@ AWS_SES_REGION_ENDPOINT = getattr(settings, 'AWS_SES_REGION_ENDPOINT',
 
 AWS_SES_AUTO_THROTTLE = getattr(settings, 'AWS_SES_AUTO_THROTTLE', 0.5)
 AWS_SES_RETURN_PATH = getattr(settings, 'AWS_SES_RETURN_PATH', None)
+AWS_SES_PROXY = getattr(settings, 'AWS_SES_PROXY', None)
+AWS_SES_PROXY_PORT = getattr(settings, 'AWS_SES_PROXY_PORT', None)
 
 DKIM_DOMAIN = getattr(settings, "DKIM_DOMAIN", None)
 DKIM_PRIVATE_KEY = getattr(settings, 'DKIM_PRIVATE_KEY', None)

--- a/django_ses/settings.py
+++ b/django_ses/settings.py
@@ -21,6 +21,8 @@ AWS_SES_AUTO_THROTTLE = getattr(settings, 'AWS_SES_AUTO_THROTTLE', 0.5)
 AWS_SES_RETURN_PATH = getattr(settings, 'AWS_SES_RETURN_PATH', None)
 AWS_SES_PROXY = getattr(settings, 'AWS_SES_PROXY', None)
 AWS_SES_PROXY_PORT = getattr(settings, 'AWS_SES_PROXY_PORT', None)
+AWS_SES_PROXY_USER = getattr(settings, 'AWS_SES_PROXY_USER', None)
+AWS_SES_PROXY_PASS = getattr(settings, 'AWS_SES_PROXY_PASS', None)
 
 DKIM_DOMAIN = getattr(settings, "DKIM_DOMAIN", None)
 DKIM_PRIVATE_KEY = getattr(settings, 'DKIM_PRIVATE_KEY', None)

--- a/django_ses/tests/test_backend.py
+++ b/django_ses/tests/test_backend.py
@@ -152,17 +152,17 @@ class SESBackendTestProxySettings(TestCase):
 
     def test_proxy_settings(self):
         send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
-        # setup args are in the first outbox message
-        received_kwargs = self.outbox.pop(0)
+        # connection setup args are in the first outbox message
+        connection_kwargs = self.outbox.pop(0)
 
-        self.assertIn('proxy', received_kwargs)
-        self.assertEqual(received_kwargs['proxy'], settings.AWS_SES_PROXY)
+        self.assertIn('proxy', connection_kwargs)
+        self.assertEqual(connection_kwargs['proxy'], settings.AWS_SES_PROXY)
 
-        self.assertIn('proxy_port', received_kwargs)
-        self.assertEqual(received_kwargs['proxy_port'], settings.AWS_SES_PROXY_PORT)
+        self.assertIn('proxy_port', connection_kwargs)
+        self.assertEqual(connection_kwargs['proxy_port'], settings.AWS_SES_PROXY_PORT)
 
-        self.assertIn('proxy_user', received_kwargs)
-        self.assertEqual(received_kwargs['proxy_user'], settings.AWS_SES_PROXY_USER)
+        self.assertIn('proxy_user', connection_kwargs)
+        self.assertEqual(connection_kwargs['proxy_user'], settings.AWS_SES_PROXY_USER)
 
-        self.assertIn('proxy_pass', received_kwargs)
-        self.assertEqual(received_kwargs['proxy_pass'], settings.AWS_SES_PROXY_PASS)
+        self.assertIn('proxy_pass', connection_kwargs)
+        self.assertEqual(connection_kwargs['proxy_pass'], settings.AWS_SES_PROXY_PASS)

--- a/django_ses/tests/test_backend.py
+++ b/django_ses/tests/test_backend.py
@@ -147,6 +147,8 @@ class SESBackendTestProxySettings(TestCase):
         self.outbox = FakeSESConnection.outbox
         settings.AWS_SES_PROXY = 'some.proxy.host.tld'
         settings.AWS_SES_PROXY_PORT = 1234
+        settings.AWS_SES_PROXY_USER = 'some-user-id'
+        settings.AWS_SES_PROXY_PASS = 'secret'
 
     def test_proxy_settings(self):
         send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
@@ -158,3 +160,9 @@ class SESBackendTestProxySettings(TestCase):
 
         self.assertIn('proxy_port', received_kwargs)
         self.assertEqual(received_kwargs['proxy_port'], settings.AWS_SES_PROXY_PORT)
+
+        self.assertIn('proxy_user', received_kwargs)
+        self.assertEqual(received_kwargs['proxy_user'], settings.AWS_SES_PROXY_USER)
+
+        self.assertIn('proxy_pass', received_kwargs)
+        self.assertEqual(received_kwargs['proxy_pass'], settings.AWS_SES_PROXY_PASS)

--- a/django_ses/tests/test_settings.py
+++ b/django_ses/tests/test_settings.py
@@ -22,7 +22,11 @@ class SettingsImportTest(TestCase):
     def test_proxy_settings_given(self):
         settings.AWS_SES_PROXY = "some.proxy.host.tld"
         settings.AWS_SES_PROXY_PORT = 1234
+        settings.AWS_SES_PROXY_USER = 'some-user-id'
+        settings.AWS_SES_PROXY_PASS = 'secret'
         unload_django_ses()
         import django_ses
         self.assertEqual(django_ses.settings.AWS_SES_PROXY, settings.AWS_SES_PROXY)
         self.assertEqual(django_ses.settings.AWS_SES_PROXY_PORT, settings.AWS_SES_PROXY_PORT)
+        self.assertEqual(django_ses.settings.AWS_SES_PROXY_USER, settings.AWS_SES_PROXY_USER)
+        self.assertEqual(django_ses.settings.AWS_SES_PROXY_PASS, settings.AWS_SES_PROXY_PASS)

--- a/django_ses/tests/test_settings.py
+++ b/django_ses/tests/test_settings.py
@@ -19,4 +19,10 @@ class SettingsImportTest(TestCase):
         self.assertEqual(django_ses.settings.ACCESS_KEY, settings.AWS_SES_ACCESS_KEY_ID)
         self.assertEqual(django_ses.settings.SECRET_KEY, settings.AWS_SES_SECRET_ACCESS_KEY)
 
-
+    def test_proxy_settings_given(self):
+        settings.AWS_SES_PROXY = "some.proxy.host.tld"
+        settings.AWS_SES_PROXY_PORT = 1234
+        unload_django_ses()
+        import django_ses
+        self.assertEqual(django_ses.settings.AWS_SES_PROXY, settings.AWS_SES_PROXY)
+        self.assertEqual(django_ses.settings.AWS_SES_PROXY_PORT, settings.AWS_SES_PROXY_PORT)

--- a/django_ses/views.py
+++ b/django_ses/views.py
@@ -129,7 +129,10 @@ def dashboard(request):
     ses_conn = SESConnection(
         aws_access_key_id=settings.ACCESS_KEY,
         aws_secret_access_key=settings.SECRET_KEY,
-        region=region)
+        region=region,
+        proxy=settings.AWS_SES_PROXY,
+        proxy_port=settings.AWS_SES_PROXY_PORT,
+    )
 
     quota_dict = ses_conn.get_send_quota()
     verified_emails_dict = ses_conn.list_verified_email_addresses()


### PR DESCRIPTION
`boto` has support for proxies, but `django_ses` does not allow specifying the parameters for that. I added support for proxy host and port. 

I have not thought of a way to write a test for this. If you have an idea, please share.