### PR TITLE
Add SES Configuration Set support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,25 @@ To turn off automatic throttling, set this to None.
 
 Check out the ``example`` directory for more information.
 
+SES Event Monitoring with Configuration Sets
+============================================
+
+You can track your SES email sending at a granular level using `SES Event Publishing 
+<https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-using-event-publishing.html>`.  
+To do this, you set up an SES Configuration Set and add event handlers to it to
+send your events on to a destination within AWS (SNS, Cloudwatch or Kinesis
+Firehose) for further processing and analysis.
+
+To ensure that emails you send via `django-ses` will be tagged with your
+SES Configuration Set, set the `AWS_SES_CONFIGURATION_SET` setting in your
+settings.py to the name of the configuration set::
+
+    AWS_SES_CONFIGURATION_SET = 'my-configuration-set-name'
+
+
+This will add the `X-SES-CONFIGURATION-SET` header to all your outgoing
+e-mails.
+
 DKIM
 ====
 

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Check out the ``example`` directory for more information.
 SES Event Monitoring with Configuration Sets
 ============================================
 
-You can track your SES email sending at a granular level using `SES Event Publishing_`.  
+You can track your SES email sending at a granular level using `SES Event Publishing`_.  
 To do this, you set up an SES Configuration Set and add event
 handlers to it to send your events on to a destination within AWS (SNS,
 Cloudwatch or Kinesis Firehose) for further processing and analysis.

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,29 @@ settings.py to the name of the configuration set::
 This will add the `X-SES-CONFIGURATION-SET` header to all your outgoing
 e-mails.
 
+If you want to set the SES Configuration Set on a per message basis, set
+`AWS_SES_CONFIGURATION_SET` to a callable.  The callable should conform to the
+following prototype::
+
+    def ses_configuration_set(message, dkim_domain=None, dkim_key=None,
+                                dkim_selector=None, dkim_headers=()):
+        configuration_set = 'my-default-set'
+        # use message and dkim_* to modify configuration_set
+        return configuration_set
+        
+    AWS_SES_CONFIGURATION_SET = ses_configuration_set
+
+where
+
+* `message` is a `django.core.mail.EmailMessage` object (or subclass)
+* `dkim_domain` is a string containing the DKIM domain for this message
+* `dkim_key` is a string containing the DKIM private key for this message
+* `dkim_selector` is a string containing the DKIM selector (see DKIM, below for
+  explanation)
+* `dkim_headers` is a list of strings containing the names of the headers to
+  be DKIM signed (see DKIM, below for explanation)
+
+
 DKIM
 ====
 
@@ -293,7 +316,9 @@ Full List of Settings
 
 ``AWS_SES_CONFIGURATION_SET``
   Optional. Use this to mark your e-mails as from being from a particular SES
-  Configuration Set.
+  Configuration Set. Set this to a string if you want all messages to have the
+  same configuration set.  Set this to a callable if you want to set
+  configuration set on a per message basis. 
 
 ``AWS_SES_PROXY``
   Optional. Use this address as a proxy while connecting to Amazon SES.

--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,8 @@ Check out the ``example`` directory for more information.
 SES Event Monitoring with Configuration Sets
 ============================================
 
-You can track your SES email sending at a granular level using `SES Event
-Publishing_`.  To do this, you set up an SES Configuration Set and add event
+You can track your SES email sending at a granular level using `SES Event Publishing_`.  
+To do this, you set up an SES Configuration Set and add event
 handlers to it to send your events on to a destination within AWS (SNS,
 Cloudwatch or Kinesis Firehose) for further processing and analysis.
 

--- a/README.rst
+++ b/README.rst
@@ -98,18 +98,16 @@ Check out the ``example`` directory for more information.
 SES Event Monitoring with Configuration Sets
 ============================================
 
-You can track your SES email sending at a granular level using `SES Event Publishing 
-<https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-using-event-publishing.html>`.  
-To do this, you set up an SES Configuration Set and add event handlers to it to
-send your events on to a destination within AWS (SNS, Cloudwatch or Kinesis
-Firehose) for further processing and analysis.
+You can track your SES email sending at a granular level using `SES Event
+Publishing_`.  To do this, you set up an SES Configuration Set and add event
+handlers to it to send your events on to a destination within AWS (SNS,
+Cloudwatch or Kinesis Firehose) for further processing and analysis.
 
 To ensure that emails you send via `django-ses` will be tagged with your
 SES Configuration Set, set the `AWS_SES_CONFIGURATION_SET` setting in your
 settings.py to the name of the configuration set::
 
     AWS_SES_CONFIGURATION_SET = 'my-configuration-set-name'
-
 
 This will add the `X-SES-CONFIGURATION-SET` header to all your outgoing
 e-mails.
@@ -265,6 +263,7 @@ has a `verify_email_address()` method: https://github.com/boto/boto/blob/master/
 .. _Django: http://djangoproject.com
 .. _Boto: http://boto.cloudhackers.com/
 .. _SES: http://aws.amazon.com/ses/
+.. _SES Event Publishing: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-using-event-publishing.html  
 __ https://github.com/bancek/django-smtp-ssl
 
 Requirements
@@ -291,6 +290,10 @@ Full List of Settings
 ``AWS_SES_RETURN_PATH``
   Instruct Amazon SES to forward bounced emails and complaints to this email.
   For more information please refer to http://aws.amazon.com/ses/faqs/#38
+
+``AWS_SES_CONFIGURATION_SET``
+  Optional. Use this to mark your e-mails as from being from a particular SES
+  Configuration Set.
 
 ``AWS_SES_PROXY``
   Optional. Use this address as a proxy while connecting to Amazon SES.

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -119,7 +119,7 @@ class SESBackend(BaseEmailBackend):
 
         num_sent = 0
         source = settings.AWS_SES_RETURN_PATH
-        for message in email_messages:
+       for message in email_messages:
             # SES Configuration sets; if the AWS_SES_CONFIGURATION_SET setting
             # is not None, append the appropriate header to the message so that
             # SES knows which configuration set it belongs to.
@@ -127,7 +127,7 @@ class SESBackend(BaseEmailBackend):
                 'X-SES-CONFIGURATION-SET' not in message.extra_headers):
                 message.extra_headers[
                     'X-SES-CONFIGURATION-SET'] = settings.AWS_SES_CONFIGURATION_SET
-                logger.debug("send_messages.configuration_set configuration_set='{}'".format(settings.AWS_SES_CONFIGURAITON_SET))
+                logger.info("send_messages.configuration_set configuration_set='{}'".format(settings.AWS_SES_CONFIGURATION_SET))
 
             # Automatic throttling. Assumes that this is the only SES client
             # currently operating. The AWS_SES_AUTO_THROTTLE setting is a
@@ -142,7 +142,7 @@ class SESBackend(BaseEmailBackend):
                 # Get and cache the current SES max-per-second rate limit
                 # returned by the SES API.
                 rate_limit = self.get_rate_limit()
-                logger.debug("send_messages.throttle rate_limit='{}'".format(rate_limit))
+                logger.info("send_messages.throttle rate_limit='{}'".format(rate_limit))
 
                 # Prune from recent_send_times anything more than a few seconds
                 # ago. Even though SES reports a maximum per-second, the way
@@ -192,7 +192,7 @@ class SESBackend(BaseEmailBackend):
                 message.extra_headers['request_id'] = response[
                     'SendRawEmailResponse']['ResponseMetadata']['RequestId']
                 num_sent += 1
-                logger.debug("send_messages.sent from='{}' recipients='{}' message_id='{}' request_id='{}'".format(
+                logger.info("send_messages.sent from='{}' recipients='{}' message_id='{}' request_id='{}'".format(
                     message.from_email,
                     ", ".join(message.recipients()),
                     message.extra_headers['message_id'],

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -116,6 +116,14 @@ class SESBackend(BaseEmailBackend):
         num_sent = 0
         source = settings.AWS_SES_RETURN_PATH
         for message in email_messages:
+            # SES Configuration sets; if the AWS_SES_CONFIGURATION_SET setting
+            # is not None, append the appropriate header to the message so that
+            # SES knows which configuration set it belongs to.
+            if (settings.AWS_SES_CONFIGURATION_SET and
+                'X-SES-CONFIGURATION-SET' not in message.extra_headers):
+                message.extra_headers[
+                    'X-SES-CONFIGURATION-SET'] = settings.AWS_SES_CONFIGURATION_SET
+
             # Automatic throttling. Assumes that this is the only SES client
             # currently operating. The AWS_SES_AUTO_THROTTLE setting is a
             # factor to apply to the rate limit, with a default of 0.5 to stay

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -119,7 +119,7 @@ class SESBackend(BaseEmailBackend):
 
         num_sent = 0
         source = settings.AWS_SES_RETURN_PATH
-       for message in email_messages:
+        for message in email_messages:
             # SES Configuration sets; if the AWS_SES_CONFIGURATION_SET setting
             # is not None, append the appropriate header to the message so that
             # SES knows which configuration set it belongs to.
@@ -127,7 +127,7 @@ class SESBackend(BaseEmailBackend):
                 'X-SES-CONFIGURATION-SET' not in message.extra_headers):
                 message.extra_headers[
                     'X-SES-CONFIGURATION-SET'] = settings.AWS_SES_CONFIGURATION_SET
-                logger.info("send_messages.configuration_set configuration_set='{}'".format(settings.AWS_SES_CONFIGURATION_SET))
+                logger.debug("send_messages.configuration_set configuration_set='{}'".format(settings.AWS_SES_CONFIGURATION_SET))
 
             # Automatic throttling. Assumes that this is the only SES client
             # currently operating. The AWS_SES_AUTO_THROTTLE setting is a
@@ -142,7 +142,7 @@ class SESBackend(BaseEmailBackend):
                 # Get and cache the current SES max-per-second rate limit
                 # returned by the SES API.
                 rate_limit = self.get_rate_limit()
-                logger.info("send_messages.throttle rate_limit='{}'".format(rate_limit))
+                logger.debug("send_messages.throttle rate_limit='{}'".format(rate_limit))
 
                 # Prune from recent_send_times anything more than a few seconds
                 # ago. Even though SES reports a maximum per-second, the way
@@ -192,7 +192,7 @@ class SESBackend(BaseEmailBackend):
                 message.extra_headers['request_id'] = response[
                     'SendRawEmailResponse']['ResponseMetadata']['RequestId']
                 num_sent += 1
-                logger.info("send_messages.sent from='{}' recipients='{}' message_id='{}' request_id='{}'".format(
+                logger.debug("send_messages.sent from='{}' recipients='{}' message_id='{}' request_id='{}'".format(
                     message.from_email,
                     ", ".join(message.recipients()),
                     message.extra_headers['message_id'],

--- a/django_ses/settings.py
+++ b/django_ses/settings.py
@@ -23,6 +23,7 @@ AWS_SES_PROXY = getattr(settings, 'AWS_SES_PROXY', None)
 AWS_SES_PROXY_PORT = getattr(settings, 'AWS_SES_PROXY_PORT', None)
 AWS_SES_PROXY_USER = getattr(settings, 'AWS_SES_PROXY_USER', None)
 AWS_SES_PROXY_PASS = getattr(settings, 'AWS_SES_PROXY_PASS', None)
+AWS_SES_CONFIGURATION_SET= getattr(settings, 'AWS_SES_CONFIGURATION_SET', None)
 
 DKIM_DOMAIN = getattr(settings, "DKIM_DOMAIN", None)
 DKIM_PRIVATE_KEY = getattr(settings, 'DKIM_PRIVATE_KEY', None)

--- a/django_ses/tests/test_backend.py
+++ b/django_ses/tests/test_backend.py
@@ -25,6 +25,26 @@ HuuR7wc0HJ/cfVi8Kgm5B+sHY9/7KDWAYGGnbGgCNA==
 DKIM_PUBLIC_KEY = 'MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALCKsjD8UUxBESo1OLN6gptp1lD0U85AgXGL571/SQ3k61KhAQ8hhL3lnfQKn/XCl2oCXscEwgJv43IUs+VETWECAwEAAQ=='
 
 
+class SESConfigurationSetTester(object):
+
+    def __init__(self, configuration_set):
+        self.message = None
+        self.dkim_domain = None
+        self.dkim_key = None
+        self.dkim_selector = None
+        self.dkim_headers = ()
+        self.configuration_set = configuration_set
+
+    def __call__(self, message, dkim_domain=None, dkim_key=None,
+                 dkim_selector=None, dkim_headers=()):
+        self.message = message
+        self.dkim_domain = dkim_domain
+        self.dkim_key = dkim_key
+        self.dkim_selector = dkim_selector
+        self.dkim_headers = dkim_headers
+        return self.configuration_set
+
+
 class FakeSESConnection(SESConnection):
     '''
     A fake SES connection for testing purposes.It behaves similarly
@@ -38,7 +58,6 @@ class FakeSESConnection(SESConnection):
 
     def __init__(self, *args, **kwargs):
         self.outbox.append(kwargs)
-
 
     def send_raw_email(self, **kwargs):
         self.outbox.append(kwargs)
@@ -97,6 +116,25 @@ class SESBackendTest(TestCase):
         self.assertEqual(mail['from'], 'from@example.com')
         self.assertEqual(mail['to'], 'to@example.com')
         self.assertEqual(mail.get_payload(), 'body')
+
+    def test_configuration_set_callable_send_mail(self):
+        config_set_callable = SESConfigurationSetTester('my-config-set')
+        settings.AWS_SES_CONFIGURATION_SET = config_set_callable
+        send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+        message = self.outbox.pop()
+        mail = email.message_from_string(smart_str(message['raw_message']))
+        # ensure we got the correct configuration message payload
+        self.assertEqual(mail['X-SES-CONFIGURATION-SET'], 'my-config-set')
+        self.assertEqual(mail['subject'], 'subject')
+        self.assertEqual(mail['from'], 'from@example.com')
+        self.assertEqual(mail['to'], 'to@example.com')
+        self.assertEqual(mail.get_payload(), 'body')
+        # ensure we passed in the proper arguments to our callable
+        self.assertEqual(config_set_callable.message.subject, 'subject')
+        self.assertEqual(config_set_callable.dkim_domain, None)
+        self.assertEqual(config_set_callable.dkim_key, None)
+        self.assertEqual(config_set_callable.dkim_selector, 'ses')
+        self.assertEqual(config_set_callable.dkim_headers, ('From', 'To', 'Cc', 'Subject'))
 
     def test_dkim_mail(self):
         settings.AWS_SES_CONFIGURATION_SET = None

--- a/django_ses/tests/test_settings.py
+++ b/django_ses/tests/test_settings.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.conf import settings
 from django_ses.tests.utils import unload_django_ses
 
+
 class SettingsImportTest(TestCase):
     def test_aws_access_key_given(self):
         settings.AWS_ACCESS_KEY_ID = "Yjc4MzQ4MGYzMTBhOWY3ODJhODhmNTBkN2QwY2IyZTdhZmU1NDM1ZQo"
@@ -30,3 +31,9 @@ class SettingsImportTest(TestCase):
         self.assertEqual(django_ses.settings.AWS_SES_PROXY_PORT, settings.AWS_SES_PROXY_PORT)
         self.assertEqual(django_ses.settings.AWS_SES_PROXY_USER, settings.AWS_SES_PROXY_USER)
         self.assertEqual(django_ses.settings.AWS_SES_PROXY_PASS, settings.AWS_SES_PROXY_PASS)
+
+    def test_ses_configuration_set_given(self):
+        settings.AWS_SES_CONFIGURATION_SET = "test-set"
+        unload_django_ses()
+        import django_ses
+        self.assertEqual(django_ses.settings.AWS_SES_CONFIGURATION_SET, settings.AWS_SES_CONFIGURATION_SET)


### PR DESCRIPTION
This allows emails sent with the appropriate SES Configuration Set header so that bounces et. al. can be handled correctly.