### PR TITLE
Add universal wheel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.db
+build/
 local_settings.py
 django_ses.egg-info
 dist/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Wheels are the new standard of python distribution.

For detailed information, see PEP 427.

https://www.python.org/dev/peps/pep-0427/

For high level information, see:

https://pythonwheels.com/

Advantages of wheels

* Faster installation for pure Python packages
* Avoids arbitrary code execution for installation (avoids `setup.py`)
* Allows better caching for testing and continuous integration
* Creates `.pyc` files as part of installation to ensure they match the python interpreter used
* More consistent installs across platforms and machines

As this package is pure Pythong (no C files), I have marked the wheel as universal.

When you'd normally run `python setup.py sdist upload`, run instead `python setup.py sdist bdist_wheel upload`.

The `LICENSE` file will be included with the wheel distribution.

Ignore `build/` directory created when building a wheel package.