### PR TITLE
Remove deprecated, ignored configuration downloadcache

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py27-django{18,19,110,111},py34-django18,py35-django{19,110,111}
-downloadcache = {toxworkdir}/.cache
 
 [testenv]
 commands =


### PR DESCRIPTION
Per tox documentation

https://tox.readthedocs.io/en/latest/config.html#confval-downloadcache=path

> downloadcache=path
>
> IGNORED – Since pip-8 has caching by default this option is now ignored. Please remove it from your configs as a future tox version might bark on it.