### PR TITLE
Use TOXENV environment variable to determine tox test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,19 @@ language: python
 python:
   - "3.5"
 env:
-    - TESTENV=py27-django18
-    - TESTENV=py27-django19
-    - TESTENV=py27-django110
-    - TESTENV=py27-django111
-    - TESTENV=py34-django18
-    - TESTENV=py35-django19
-    - TESTENV=py35-django110
-    - TESTENV=py35-django111
+    - TOXENV=py27-django18
+    - TOXENV=py27-django19
+    - TOXENV=py27-django110
+    - TOXENV=py27-django111
+    - TOXENV=py34-django18
+    - TOXENV=py35-django19
+    - TOXENV=py35-django110
+    - TOXENV=py35-django111
 
 before_install:
     - pip3 install tox
 
-script: tox -e $TESTENV
+script: tox
 
 notifications:
   email: false


### PR DESCRIPTION
Current approach of using a different environment variable, effectively duplicates this builtin feature.

For information on using this environment variable, see documentation:

https://tox.readthedocs.io/en/latest/config.html#confval-envlist=CSV
https://tox.readthedocs.io/en/latest/example/general.html#selecting-one-or-more-environments-to-run-tests-against