### PR TITLE
Test against latest Django 1.11 instead of the beta

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ deps =
     {py27,py34}-django18: Django>=1.8,<1.9
     {py27,py35}-django19: Django>=1.9,<1.10
     {py27,py35}-django110: Django>=1.10,<1.11
-    {py27,py35}-django111: Django==1.11b1
+    {py27,py35}-django111: Django>=1.11,<2.0


### PR DESCRIPTION
The test matrix now always tests against the latest Django version for all.