### PR TITLE
Fix error in bounce notification verification on Python 2  

### DIFF
--- a/django_ses/utils.py
+++ b/django_ses/utils.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+from builtins import str as text
 from io import StringIO
 try:
     from urllib.parse import urlparse
@@ -172,10 +173,10 @@ class BounceMessageVerifier(object):
             field_value = smart_str(self._data.get(field_name, ''),
                                     errors="replace")
             if field_value:
-                outbytes.write(field_name)
-                outbytes.write("\n")
-                outbytes.write(field_value)
-                outbytes.write("\n")
+                outbytes.write(text(field_name))
+                outbytes.write(text("\n"))
+                outbytes.write(text(field_value))
+                outbytes.write(text("\n"))
 
         return outbytes.getvalue()
 

--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,6 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=['any'],
     classifiers=CLASSIFIERS,
-    install_requires=["boto>=2.31.0", "pytz>=2016.10"],
+    install_requires=["boto>=2.31.0", "pytz>=2016.10", "future>=0.16.0"],
     include_package_data=True,
 )

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -77,3 +77,9 @@ class BounceMessageVerifierTest(TestCase):
             'SigningCertURL': 'https://www.example.com/',
         })
         self.assertEqual(verifier._get_cert_url(), None)
+
+    def test_get_bytes_to_sign(self):
+        verifier = BounceMessageVerifier({
+            'Type': 'Notification'
+        })
+        self.assertEqual(verifier._get_bytes_to_sign(), 'Type\nNotification\n')


### PR DESCRIPTION
I came across the same issue reported here: https://github.com/django-ses/django-ses/issues/141. This PR fixes the error as well as adding a test for it.

The error comes from the fact that `outbytes.write()` is expecting a unicode string, this works fine in Python 3 but Python 2 strings aren't unicode by default. This can be fixed by using `from builtins import str` which will cast Python 2 strings to `newstr` which are unicode, whilst not affecting Python 3 strings.