### PR TITLE
tests: allow to specify args, e.g. a single test to run

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -12,6 +12,8 @@ kick off the test suite.
 # `DATABASES` value be present and configured in order to
 # do anything.
 
+import sys
+
 import django
 from django.conf import settings
 from django.core.management import call_command
@@ -34,4 +36,4 @@ settings.configure(
 django.setup()
 
 # Start the test suite now that the settings are configured.
-call_command("test", "tests")
+call_command("test", *sys.argv[1:])

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = django{18,19,110,111}
 
 [testenv]
 commands =
-    python runtests.py
+    python runtests.py {posargs:tests}
 deps =
     mock
     django18: Django>=1.8,<1.9


### PR DESCRIPTION
This allows for

    tox -e py36-django111 -- tests.test_backend.SESBackendTest.test_dkim_mail