### PR TITLE
Don't catch BaseExceptions

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -91,7 +91,7 @@ class SESBackend(BaseEmailBackend):
                 proxy_user=self._proxy_user,
                 proxy_pass=self._proxy_pass,
             )
-        except:
+        except Exception:
             if not self.fail_silently:
                 raise
 
@@ -101,7 +101,7 @@ class SESBackend(BaseEmailBackend):
         try:
             self.connection.close()
             self.connection = None
-        except:
+        except Exception:
             if not self.fail_silently:
                 raise
 

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ DESCRIPTION = "A Django email backend for Amazon's Simple Email Service"
 LONG_DESCRIPTION = None
 try:
     LONG_DESCRIPTION = open('README.rst').read()
-except:
+except Exception:
     pass
 
 CLASSIFIERS = [


### PR DESCRIPTION
Exiting exceptions, such as `KeyboardInterrupt`, inherit from `BaseException` rather than `Exception`. The idiomatic way to catch any unexpected exception is to only catch `Exception`, so that `BaseExceptions` still bubble up.