### PR TITLE
Fix Python 2 and 3 compatible to_bytes using future

### DIFF
--- a/django_ses/utils.py
+++ b/django_ses/utils.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 from builtins import str as text
+from builtins import bytes
 from io import StringIO
 try:
     from urllib.parse import urlparse
@@ -39,7 +40,7 @@ class BounceMessageVerifier(object):
                 return self._verified
 
             # Decode the signature from base64
-            signature = base64.b64decode(signature)
+            signature = bytes(base64.b64decode(signature))
 
             # Get the message to sign
             sign_bytes = self._get_bytes_to_sign()
@@ -179,7 +180,7 @@ class BounceMessageVerifier(object):
                 outbytes.write(text("\n"))
 
         response = outbytes.getvalue()
-        return to_bytes(response)
+        return bytes(response, 'utf-8')
 
 
 def verify_bounce_message(msg):
@@ -188,10 +189,3 @@ def verify_bounce_message(msg):
     """
     verifier = BounceMessageVerifier(msg)
     return verifier.is_verified()
-
-
-def to_bytes(bytes_or_str):
-    # From: https://stackoverflow.com/a/46037362
-    if isinstance(bytes_or_str, str):
-        return bytes_or_str.encode('utf-8')
-    return bytes_or_str

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -83,4 +83,6 @@ class BounceMessageVerifierTest(TestCase):
         verifier = BounceMessageVerifier({
             'Type': 'Notification'
         })
-        self.assertEqual(verifier._get_bytes_to_sign(), b'Type\nNotification\n')
+        result = verifier._get_bytes_to_sign()
+        self.assertEqual(result, b'Type\nNotification\n')
+        self.assertTrue(isinstance(result, bytes))


### PR DESCRIPTION
I previously fixed an issue with Python 2 compatibility of SNS notification validation here: https://github.com/django-ses/django-ses/pull/143. However that revealed another issue which was reported in this issue: https://github.com/django-ses/django-ses/issues/157. I wasn't able to fix this issue at that time, but I now had a chance to have another look at this.

The problem is related to the fact that `StringIO.getvalue()` and `base64.b64decode` return different types in Python 2 and 3:
```python
# Python 2.7
>>> outbytes = StringIO()
>>> outbytes.write(text("a"))
>>> type(outbytes.getvalue())
<type 'unicode'>

# Python 3.7
>>> outbytes = StringIO()
>>> outbytes.write(text("a"))
>>> type(outbytes.getvalue())
<class 'str'>
```

```python
# Python 2.7
>>> type(base64.b64decode('YQ=='))
<type 'str'>

# Python 3.7
>>> type(base64.b64decode('YQ=='))
<class 'bytes'>
```

You fixed this for Python 3 by casting the `str` from `outbytes.getvalue()` to a `bytes` so that it matches the type returned by `b64decode`. However, this doesn't work for Python 2 because the types are different.

So this PR changes fixes this by making use of `bytes()` function from [future](http://python-future.org/bytes_object.html). This won't change any of the functionality for Python 3, but it will change Python 2 to use a `bytes` compatible class:
```python
# Python 2.7
>>> type(bytes(outbytes.getvalue(), 'utf-8'))
<class 'future.types.newbytes.newbytes'>

# Python 3.7
>>> type(bytes(outbytes.getvalue(), 'utf-8'))
<class 'bytes'>
```

```python
# Python 2.7
>>> type(bytes(base64.b64decode('YQ==')))
<class 'future.types.newbytes.newbytes'>

# Python 3.7
>>> type(bytes(base64.b64decode('YQ==')))
<class 'bytes'>
```


Additionally I modified the test to check that what was returned from `_get_bytes_to_sign()` was actually a `bytes` object.