### PR TITLE
Added a `bounce` extra to `setup.py`. Fixes #171

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,11 @@ Check out the ``example`` directory for more information.
 
 Monitoring email status using Amazon Simple Notification Service (Amazon SNS)
 =============================================================================
-For integrate this service, install `django-ses` with the `bounce` extra::
+To set this up, install `django-ses` with the `bounce` extra::
 
     pip install django-ses[bounce]
 
-Then add the next url in you urls.py file, and create Topics and configure
+Then add a bounce url handler in your `urls.py`, create Topics and configure
 Subscription in Amazon::
 
     from django_ses.views import handle_bounce
@@ -111,8 +111,7 @@ Subscription in Amazon::
                     ...
     ]
 
-For manage status of emails through Amazon SNS has three signals for manage each
-status (bounce, complaint, delivery).
+Amazon SNS has three signals for each status (bounce, complaint, delivery).
 
 Bounces
 -------

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,12 @@ Check out the ``example`` directory for more information.
 
 Monitoring email status using Amazon Simple Notification Service (Amazon SNS)
 =============================================================================
-For integrate this service, add the next url in you urls.py file, create
-Topics and configure Subscription in Amazon::
+For integrate this service, install `django-ses` with the `bounce` extra::
+
+    pip install django-ses[bounce]
+
+Then add the next url in you urls.py file, and create Topics and configure
+Subscription in Amazon::
 
     from django_ses.views import handle_bounce
     from django.views.decorators.csrf import csrf_exempt

--- a/setup.py
+++ b/setup.py
@@ -143,4 +143,7 @@ setup(
     classifiers=CLASSIFIERS,
     install_requires=["boto>=2.31.0", "pytz>=2016.10", "future>=0.16.0"],
     include_package_data=True,
+    extras_require={
+        'bounce': ['requests', 'M2Crypto'],
+    },
 )


### PR DESCRIPTION
This extra tracks the `requests` and `M2Crypto` packages as
dependencies, which are required for bounce message verification.