### PR TITLE
Add AppConfig with verbose_name

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -10,6 +10,8 @@ from datetime import datetime, timedelta
 from time import sleep
 
 
+default_app_config = 'django_ses.apps.DjangoSESConfig'
+
 # When changing this, remember to change it in setup.py
 VERSION = (0, "8", 12)
 __version__ = '.'.join([str(x) for x in VERSION])

--- a/django_ses/apps.py
+++ b/django_ses/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DjangoSESConfig(AppConfig):
+    name = 'django_ses'
+    verbose_name = 'Django SES'


### PR DESCRIPTION
Added `AppConfig` according do the [Django documentation](https://docs.djangoproject.com/en/2.2/ref/applications/#for-application-authors). The package will now appear as "Django SES" in admin panel instead of "DJANGO_SES" or "Django_Ses". This is more of a cosmetic change, everything else remains the same.

Django admin panel before:
![image](https://user-images.githubusercontent.com/16157837/70248064-adf22d00-177a-11ea-80dd-d39081f21fca.png)

Django admin panel now:
![image](https://user-images.githubusercontent.com/16157837/70248364-0f1a0080-177b-11ea-909c-7312a4b383da.png)