### PR TITLE
Add test config for Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,42 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
 env:
     - TOXENV=django111
     - TOXENV=django20
     - TOXENV=django21
     - TOXENV=django22
+    - TOXENV=django30
 matrix:
     exclude:
+    - python: 3.8
+      env: TOXENV=django111
     - python: 2.7
       env: TOXENV=django20
     - python: 3.4
       env: TOXENV=django20
     - python: 3.5
       env: TOXENV=django20
+    - python: 3.8
+      env: TOXENV=django20
     - python: 2.7
       env: TOXENV=django21
     - python: 3.4
+      env: TOXENV=django21
+    - python: 3.8
       env: TOXENV=django21
     - python: 2.7
       env: TOXENV=django22
     - python: 3.4
       env: TOXENV=django22
+    - python: 2.7
+      env: TOXENV=django30
+    - python: 3.4
+      env: TOXENV=django30
+    - python: 3.5
+      env: TOXENV=django30
 
 before_install:
     - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{111,20,21,22}
+envlist = django{111,20,21,22,30}
 
 [testenv]
 commands =
@@ -10,6 +10,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2a1,<3.0
+    django30: Django>=3.0,<3.1
 # Per https://github.com/travis-ci/travis-ci/issues/7940, the Travis CI
 # image for trusty has a problem with its /etc/boto.cfg. Because tox
 # isolates environments, we specify the BOTO_CONFIG env var here:


### PR DESCRIPTION
Adds configuration test against Django 3.0 and it's relevant Python versions with excludes for older versions of Django.