### PR TITLE
event type fix and better AWS bounce setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,8 +101,7 @@ To set this up, install `django-ses` with the `bounce` extra::
 
     pip install django-ses[bounce]
 
-Then add a bounce url handler in your `urls.py`, create Topics and configure
-Subscription in Amazon::
+Then add a bounce url handler in your `urls.py`::
 
     from django_ses.views import handle_bounce
     from django.views.decorators.csrf import csrf_exempt
@@ -112,6 +111,18 @@ Subscription in Amazon::
     ]
 
 Amazon SNS has three signals for each status (bounce, complaint, delivery).
+
+On AWS
+-------
+1. Add an SNS topic.
+
+2. In SES setup an SNS destination in "Configuration Sets". Use this
+configuration set by setting ``AWS_SES_CONFIGURATION_SET``. Set the topic
+to what you created in 1.
+
+3. Add an https subscriber to the topic. (eg. https://www.yourdomain.com/ses/bounce/)
+Do not check "Enable raw message delivery".
+
 
 Bounces
 -------

--- a/django_ses/views.py
+++ b/django_ses/views.py
@@ -236,9 +236,9 @@ def handle_bounce(request):
             })
         else:
             mail_obj = message.get('mail')
-            notification_type = message.get('notificationType')
+            event_type = message.get('eventType')
 
-            if notification_type == 'Bounce':
+            if event_type == 'Bounce':
                 # Bounce
                 bounce_obj = message.get('bounce', {})
 
@@ -260,7 +260,7 @@ def handle_bounce(request):
                     bounce_obj=bounce_obj,
                     raw_message=raw_json,
                 )
-            elif notification_type == 'Complaint':
+            elif event_type == 'Complaint':
                 # Complaint
                 complaint_obj = message.get('complaint', {})
 
@@ -280,7 +280,7 @@ def handle_bounce(request):
                     complaint_obj=complaint_obj,
                     raw_message=raw_json,
                 )
-            elif notification_type == 'Delivery':
+            elif event_type == 'Delivery':
                 # Delivery
                 delivery_obj = message.get('delivery', {})
 
@@ -303,7 +303,7 @@ def handle_bounce(request):
             else:
                 # We received an unknown notification type. Just log and
                 # ignore it.
-                logger.warning(u"Received unknown notification", extra={
+                logger.warning(u"Received unknown event", extra={
                     'notification': notification,
                 })
     else:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -63,7 +63,7 @@ class HandleBounceTest(TestCase):
         }
 
         message_obj = {
-            'notificationType': 'Bounce',
+            'eventType': 'Bounce',
             'mail': req_mail_obj,
             'bounce': req_bounce_obj,
         }
@@ -126,7 +126,7 @@ class HandleBounceTest(TestCase):
         }
 
         message_obj = {
-            'notificationType': 'Complaint',
+            'eventType': 'Complaint',
             'mail': req_mail_obj,
             'complaint': req_complaint_obj,
         }


### PR DESCRIPTION
AWS notifications look like this:
```
{
  "Type" : "Notification",
  "MessageId" : "cd358678-b3e1-5281-9881-d0e35abe0a4c",
  "TopicArn" : "arn:aws:sns:us-west-(redacted):bounces_and_complaints",
  "Subject" : "Amazon SES Email Event Notification",
  "Message" : "{\"eventType\":\"Bounce\",
    \"bounce\":{
...
```

So this fixes the view code to look at the right property.