### PR TITLE
Removed `providing_args` for signals referring to deprecation warning…

### DIFF
--- a/django_ses/signals.py
+++ b/django_ses/signals.py
@@ -1,7 +1,7 @@
 from django.dispatch import Signal
 
-bounce_received = Signal(providing_args=["mail_obj", "bounce_obj", "raw_message"])
+bounce_received = Signal()
 
-complaint_received = Signal(providing_args=["mail_obj", "complaint_obj", "raw_message"])
+complaint_received = Signal()
 
-delivery_received = Signal(providing_args=["mail_obj", "delivery_obj", "raw_message"])
+delivery_received = Signal()

--- a/django_ses/signals.py
+++ b/django_ses/signals.py
@@ -1,7 +1,6 @@
 from django.dispatch import Signal
 
+# The following fields are used from the 3 signals below: mail_obj, bounce_obj, raw_message
 bounce_received = Signal()
-
 complaint_received = Signal()
-
 delivery_received = Signal()


### PR DESCRIPTION
Fixes https://github.com/django-ses/django-ses/issues/191