### PR TITLE
Fix admin dashboard broken during boto3 upgrade

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,88 +1,88 @@
+import pytz
+from datetime import datetime
+
 from django.test import TestCase
 
-from django_ses.views import (emails_parse, stats_to_list, quota_parse,
-                              sum_stats)
+from django_ses.views import emails_parse, stats_to_list, sum_stats
 
 # Mock of what boto's SESConnection.get_send_statistics() returns
 STATS_DICT = {
     u'SendDataPoints': [
         {
-            u'Bounces': u'1',
-            u'Complaints': u'0',
-            u'DeliveryAttempts': u'11',
-            u'Rejects': u'0',
-            u'Timestamp': u'2011-02-28T13:50:00Z',
+            u'Bounces': 1,
+            u'Complaints': 0,
+            u'DeliveryAttempts': 11,
+            u'Rejects': 0,
+            u'Timestamp':
+                datetime(2011, 2, 28, 13, 50, tzinfo=pytz.utc),
         },
         {
-            u'Bounces': u'1',
-            u'Complaints': u'0',
-            u'DeliveryAttempts': u'3',
-            u'Rejects': u'0',
-            u'Timestamp': u'2011-02-24T23:35:00Z',
+            u'Bounces': 1,
+            u'Complaints': 0,
+            u'DeliveryAttempts': 3,
+            u'Rejects': 0,
+            u'Timestamp':
+                datetime(2011, 2, 24, 23, 35, tzinfo=pytz.utc),
         },
         {
-            u'Bounces': u'0',
-            u'Complaints': u'2',
-            u'DeliveryAttempts': u'8',
-            u'Rejects': u'0',
-            u'Timestamp': u'2011-02-24T16:35:00Z',
+            u'Bounces': 0,
+            u'Complaints': 2,
+            u'DeliveryAttempts': 8,
+            u'Rejects': 0,
+            u'Timestamp':
+                datetime(2011, 2, 24, 16, 35, tzinfo=pytz.utc),
         },
         {
-            u'Bounces': u'0',
-            u'Complaints': u'2',
-            u'DeliveryAttempts': u'33',
-            u'Rejects': u'0',
-            u'Timestamp': u'2011-02-25T20:35:00Z',
+            u'Bounces': 0,
+            u'Complaints': 2,
+            u'DeliveryAttempts': 33,
+            u'Rejects': 0,
+            u'Timestamp':
+                datetime(2011, 2, 25, 20, 35, tzinfo=pytz.utc),
         },
         {
-            u'Bounces': u'0',
-            u'Complaints': u'0',
-            u'DeliveryAttempts': u'3',
-            u'Rejects': u'3',
-            u'Timestamp': u'2011-02-28T23:35:00Z',
+            u'Bounces': 0,
+            u'Complaints': 0,
+            u'DeliveryAttempts': 3,
+            u'Rejects': 3,
+            u'Timestamp':
+                datetime(2011, 2, 28, 23, 35, tzinfo=pytz.utc),
         },
         {
-            u'Bounces': u'0',
-            u'Complaints': u'0',
-            u'DeliveryAttempts': u'2',
-            u'Rejects': u'3',
-            u'Timestamp': u'2011-02-25T22:50:00Z',
+            u'Bounces': 0,
+            u'Complaints': 0,
+            u'DeliveryAttempts': 2,
+            u'Rejects': 3,
+            u'Timestamp':
+                datetime(2011, 2, 25, 22, 50, tzinfo=pytz.utc),
         },
         {
-            u'Bounces': u'0',
-            u'Complaints': u'0',
-            u'DeliveryAttempts': u'6',
-            u'Rejects': u'0',
-            u'Timestamp': u'2011-03-01T13:20:00Z',
+            u'Bounces': 0,
+            u'Complaints': 0,
+            u'DeliveryAttempts': 6,
+            u'Rejects': 0,
+            u'Timestamp':
+                datetime(2011, 3, 1, 13, 20, tzinfo=pytz.utc),
         },
     ],
 }
 
-QUOTA_DICT = {
-    u'GetSendQuotaResponse': {
-        u'GetSendQuotaResult': {
-            u'Max24HourSend': u'10000.0',
-            u'MaxSendRate': u'5.0',
-            u'SentLast24Hours': u'1677.0'
-        },
-        u'ResponseMetadata': {
-            u'RequestId': u'8f100233-44e7-11e0-a926-a198963635d8'
-        }
-    }
-}
-
 VERIFIED_EMAIL_DICT = {
-    u'ListVerifiedEmailAddressesResponse': {
-        u'ListVerifiedEmailAddressesResult': {
-            u'VerifiedEmailAddresses': [
-                u'test2@example.com',
-                u'test1@example.com',
-                u'test3@example.com'
-            ]
+    u'VerifiedEmailAddresses': [
+        u'test2@example.com',
+        u'test1@example.com',
+        u'test3@example.com'
+    ],
+    u'ResponseMetadata': {
+        u'RequestId': u'9afe9c18-44ed-11e0-802a-25a1a14c5a6e',
+        u'HTTPStatusCode': 200,
+        u'HTTPHeaders': {
+            u'x-amzn-requestid': u'9afe9c18-44ed-11e0-802a-25a1a14c5a6e',
+            u'content-type': u'text/xml',
+            u'content-length': u'536',
+            u'date': u'Thu, 20 Aug 2020 05:06:35 GMT'
         },
-        u'ResponseMetadata': {
-            u'RequestId': u'9afe9c18-44ed-11e0-802a-25a1a14c5a6e'
-        }
+        u'RetryAttempts': 0
     }
 }
 
@@ -90,75 +90,71 @@ VERIFIED_EMAIL_DICT = {
 class StatParsingTest(TestCase):
     def setUp(self):
         self.stats_dict = STATS_DICT
-        self.quota_dict = QUOTA_DICT
         self.emails_dict = VERIFIED_EMAIL_DICT
 
     def test_stat_to_list(self):
         expected_list = [
             {
-                u'Bounces': u'0',
-                u'Complaints': u'2',
-                u'DeliveryAttempts': u'8',
-                u'Rejects': u'0',
-                u'Timestamp': u'2011-02-24T16:35:00Z',
+                u'Bounces': 0,
+                u'Complaints': 2,
+                u'DeliveryAttempts': 8,
+                u'Rejects': 0,
+                u'Timestamp':
+                    datetime(2011, 2, 24, 16, 35, tzinfo=pytz.utc),
             },
             {
-                u'Bounces': u'1',
-                u'Complaints': u'0',
-                u'DeliveryAttempts': u'3',
-                u'Rejects': u'0',
-                u'Timestamp': u'2011-02-24T23:35:00Z',
+                u'Bounces': 1,
+                u'Complaints': 0,
+                u'DeliveryAttempts': 3,
+                u'Rejects': 0,
+                u'Timestamp':
+                    datetime(2011, 2, 24, 23, 35, tzinfo=pytz.utc),
             },
             {
-                u'Bounces': u'0',
-                u'Complaints': u'2',
-                u'DeliveryAttempts': u'33',
-                u'Rejects': u'0',
-                u'Timestamp': u'2011-02-25T20:35:00Z',
+                u'Bounces': 0,
+                u'Complaints': 2,
+                u'DeliveryAttempts': 33,
+                u'Rejects': 0,
+                u'Timestamp':
+                    datetime(2011, 2, 25, 20, 35, tzinfo=pytz.utc),
             },
             {
-                u'Bounces': u'0',
-                u'Complaints': u'0',
-                u'DeliveryAttempts': u'2',
-                u'Rejects': u'3',
-                u'Timestamp': u'2011-02-25T22:50:00Z',
+                u'Bounces': 0,
+                u'Complaints': 0,
+                u'DeliveryAttempts': 2,
+                u'Rejects': 3,
+                u'Timestamp':
+                    datetime(2011, 2, 25, 22, 50, tzinfo=pytz.utc),
             },
             {
-                u'Bounces': u'1',
-                u'Complaints': u'0',
-                u'DeliveryAttempts': u'11',
-                u'Rejects': u'0',
-                u'Timestamp': u'2011-02-28T13:50:00Z',
+                u'Bounces': 1,
+                u'Complaints': 0,
+                u'DeliveryAttempts': 11,
+                u'Rejects': 0,
+                u'Timestamp':
+                    datetime(2011, 2, 28, 13, 50, tzinfo=pytz.utc),
             },
             {
-                u'Bounces': u'0',
-                u'Complaints': u'0',
-                u'DeliveryAttempts': u'3',
-                u'Rejects': u'3',
-                u'Timestamp': u'2011-02-28T23:35:00Z',
+                u'Bounces': 0,
+                u'Complaints': 0,
+                u'DeliveryAttempts': 3,
+                u'Rejects': 3,
+                u'Timestamp':
+                    datetime(2011, 2, 28, 23, 35, tzinfo=pytz.utc),
             },
             {
-                u'Bounces': u'0',
-                u'Complaints': u'0',
-                u'DeliveryAttempts': u'6',
-                u'Rejects': u'0',
-                u'Timestamp': u'2011-03-01T13:20:00Z',
+                u'Bounces': 0,
+                u'Complaints': 0,
+                u'DeliveryAttempts': 6,
+                u'Rejects': 0,
+                u'Timestamp':
+                    datetime(2011, 3, 1, 13, 20, tzinfo=pytz.utc),
             },
         ]
         actual = stats_to_list(self.stats_dict, localize=False)
 
         self.assertEqual(len(actual), len(expected_list))
         self.assertEqual(actual, expected_list)
-
-    def test_quota_parse(self):
-        expected = {
-            u'Max24HourSend': u'10000.0',
-            u'MaxSendRate': u'5.0',
-            u'SentLast24Hours': u'1677.0',
-        }
-        actual = quota_parse(self.quota_dict)
-
-        self.assertEqual(actual, expected)
 
     def test_emails_parse(self):
         expected_list = [


### PR DESCRIPTION
This is a fix for https://github.com/django-ses/django-ses/issues/188 and related dashboard issues.

- With the boto3 upgrade, the formats of the response dicts from `get_send_quota()`, `list_verified_email_addresses()`, and `get_send_statistics()` changed, which was causing issues.
- I removed `quota_parse()` because the keys needed from it are now at the root level. Because there aren't unit tests for the `dashboard()` function, this means this part isn't fully tested. This means `QUOTA_DICT` was removed as well. Below is an example of the new format if someone wants to add more testing there:
```
QUOTA_DICT = {
    u'Max24HourSend': 10000.0,
    u'MaxSendRate': 5.0,
    u'SentLast24Hours': 1677.0,
    u'ResponseMetadata': {
        u'RequestId': u'8f100233-44e7-11e0-a926-a198963635d8',
        u'HTTPStatusCode': 200,
        u'HTTPHeaders': {
            u'x-amzn-requestid': u'8f100233-44e7-11e0-a926-a198963635d8',
            u'content-type': u'text/xml',
            u'content-length': u'374',
            u'date': u'Thu, 20 Aug 2020 04:57:52 GMT'
        },
        u'RetryAttempts': 0
    }
}
```

<img width="1186" alt="Screen Shot 2020-08-20 at 2 23 04 AM" src="https://user-images.githubusercontent.com/3298145/90724173-1bec6f00-e28c-11ea-8d24-4b0dd6f1b0f9.png">
