### PR TITLE
Improve email monitoring/tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ django_ses.egg-info
 dist/*
 .DS_Store
 .tox/*
+.idea

--- a/README.rst
+++ b/README.rst
@@ -105,16 +105,16 @@ To set this up, install `django-ses` with the `bounce` extra::
 
     pip install django-ses[bounce]
 
-Then add a bounce url handler in your `urls.py`::
+Then add a event url handler in your `urls.py`::
 
-    from django_ses.views import handle_bounce
+    from django_ses.views import handle_event
     from django.views.decorators.csrf import csrf_exempt
     urlpatterns = [ ...
-                    url(r'^ses/bounce/$', csrf_exempt(handle_bounce)),
+                    url(r'^ses/event/$', csrf_exempt(handle_event)),
                     ...
     ]
 
-Amazon SNS has three signals for each status (bounce, complaint, delivery).
+Amazon SNS has three signals for each status (bounce, complaint, send, delivery, open, click).
 
 On AWS
 -------
@@ -124,7 +124,7 @@ On AWS
 configuration set by setting ``AWS_SES_CONFIGURATION_SET``. Set the topic
 to what you created in 1.
 
-3. Add an https subscriber to the topic. (eg. https://www.yourdomain.com/ses/bounce/)
+3. Add an https subscriber to the topic. (eg. https://www.yourdomain.com/ses/event/)
 Do not check "Enable raw message delivery".
 
 
@@ -137,9 +137,13 @@ Using signal 'bounce_received' for manager bounce email. For example::
 
 
     @receiver(bounce_received)
-    def bounce_handler(sender, *args, **kwargs):
+    def bounce_handler(sender, mail_obj, bounce_obj, raw_message, *args, **kwargs):
+        # you can then use the message ID and/or recipient_list(email address) to identify any problematic email messages that you have sent
+        message_id = mail_obj['messageId']
+        recipient_list = mail_obj['destination']
+        ...
         print("This is bounce email object")
-        print(kwargs.get('mail_obj'))
+        print(mail_obj)
 
 Complaint
 ---------
@@ -150,9 +154,20 @@ Using signal 'complaint_received' for manager complaint email. For example::
 
 
     @receiver(complaint_received)
-    def complaint_handler(sender, *args, **kwargs):
-        print("This is complaint email object")
-        print(kwargs.get('mail_obj'))
+    def complaint_handler(sender, mail_obj, complaint_obj, raw_message,  *args, **kwargs):
+        ...
+
+Send
+----
+Using signal 'send_received' for manager send email. For example::
+
+    from django_ses.signals import send_received
+    from django.dispatch import receiver
+
+
+    @receiver(send_received)
+    def send_handler(sender, mail_obj, send_obj, raw_message,  *args, **kwargs):
+        ...
 
 Delivery
 --------
@@ -163,9 +178,32 @@ Using signal 'delivery_received' for manager delivery email. For example::
 
 
     @receiver(delivery_received)
-    def delivery_handler(sender, *args, **kwargs):
-        print("This is delivery email object")
-        print(kwargs.get('mail_obj'))
+    def delivery_handler(sender, mail_obj, delivery_obj, raw_message,  *args, **kwargs):
+        ...
+
+Open
+----
+Using signal 'open_received' for manager open email. For example::
+
+    from django_ses.signals import open_received
+    from django.dispatch import receiver
+
+
+    @receiver(open_received)
+    def open_handler(sender, mail_obj, open_obj, raw_message, *args, **kwargs):
+        ...
+
+Click
+-----
+Using signal 'click_received' for manager send email. For example::
+
+    from django_ses.signals import click_received
+    from django.dispatch import receiver
+
+
+    @receiver(click_received)
+    def click_handler(sender, mail_obj, bounce_obj, raw_message, *args, **kwargs):
+        ...
 
 SES Event Monitoring with Configuration Sets
 ============================================

--- a/django_ses/signals.py
+++ b/django_ses/signals.py
@@ -4,3 +4,6 @@ from django.dispatch import Signal
 bounce_received = Signal()
 complaint_received = Signal()
 delivery_received = Signal()
+send_received = Signal()
+open_received = Signal()
+click_received = Signal()

--- a/django_ses/utils.py
+++ b/django_ses/utils.py
@@ -191,9 +191,16 @@ class BounceMessageVerifier(object):
         return bytes(response, 'utf-8')
 
 
-def verify_bounce_message(msg):
+def verify_event_message(msg):
     """
-    Verify an SES/SNS bounce notification message.
+    Verify an SES/SNS event notification message.
     """
     verifier = BounceMessageVerifier(msg)
     return verifier.is_verified()
+
+
+def verify_bounce_message(msg):
+    """
+    Verify an SES/SNS bounce(event) notification message.
+    """
+    return verify_event_message(msg)

--- a/example/urls.py
+++ b/example/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     url(r'^send-email/$', views.send_email, name='send-email'),
     url(r'^reporting/', include('django_ses.urls')),
 
-    url(r'^bounce/', 'django_ses.views.handle_bounce', name='handle_bounce'),
+    url(r'^event/', 'django_ses.views.handle_event', name='handle_event'),
 ]
 
 urlpatterns += staticfiles_urlpatterns()

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url
 
-from django_ses.views import dashboard, handle_bounce
+from django_ses.views import dashboard, handle_bounce, handle_event
 
 urlpatterns = [
     url(r'^dashboard/$', dashboard, name='django_ses_stats'),
     url(r'^bounce/$', handle_bounce, name='django_ses_bounce'),
+    url(r'^event/$', handle_event, name='django_ses_event'),
 ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,8 @@
 import json
+from unittest.mock import MagicMock, ANY
+
+from django_ses.views import handle_bounce, handle_event
+
 try:
     from unittest import mock
 except ImportError:
@@ -7,11 +11,137 @@ except ImportError:
 from django.test import TestCase
 from django.urls import reverse
 
-from django_ses.signals import bounce_received, complaint_received
+from django_ses.signals import bounce_received, complaint_received, send_received, delivery_received, open_received, \
+    click_received
 from django_ses import utils as ses_utils
 
 
-class HandleBounceTest(TestCase):
+def get_mock_email():
+    return {
+        "timestamp": "2012-05-25T14:59:38.623-07:00",
+        "messageId": "000001378603177f-7a5433e7-8edb-42ae-af10-f0181f34d6ee-000000",
+        "source": "sender@example.com",
+        "destination": [
+            "recipient1@example.com",
+            "recipient2@example.com",
+            "recipient3@example.com",
+            "recipient4@example.com"
+        ]
+    }
+
+
+def get_mock_notification(message):
+    return {
+        "Type": "Notification",
+        "MessageId": "22b80b92-fdea-4c2c-8f9d-bdfb0c7bf324",
+        "TopicArn": "arn:aws:sns:us-east-1:123456789012:MyTopic",
+        "Subject": "Amazon SES Email Event Notification",
+        "Message": json.dumps(message),
+        "Timestamp": "2012-05-02T00:54:06.655Z",
+        "SignatureVersion": "1",
+        "Signature": "",
+        "SigningCertURL": "",
+        "UnsubscribeURL": ""
+    }
+
+
+def get_mock_bounce():
+    mail = get_mock_email()
+    bounce = {
+        "bounceType": "Permanent",
+        "bounceSubType": "General",
+        "bouncedRecipients": [
+            {
+                "status": "5.0.0",
+                "action": "failed",
+                "diagnosticCode": "smtp; 550 user unknown",
+                "emailAddress": "recipient1@example.com",
+            },
+            {
+                "status": "4.0.0",
+                "action": "delayed",
+                "emailAddress": "recipient2@example.com",
+            }
+        ],
+        "reportingMTA": "example.com",
+        "timestamp": "2012-05-25T14:59:38.605-07:00",
+        "feedbackId": "000001378603176d-5a4b5ad9-6f30-4198-a8c3-b1eb0c270a1d-000000",
+    }
+
+    message = {
+        "eventType": "Bounce",
+        "mail": mail,
+        "bounce": bounce,
+    }
+    notification = get_mock_notification(message)
+    return mail, bounce, notification
+
+
+def get_mock_send():
+    mail = get_mock_email()
+    send = {}
+    message = {
+        "eventType": "Send",
+        "mail": mail,
+        "send": send,
+    }
+    notification = get_mock_notification(message)
+    return mail, send, notification
+
+
+def get_mock_delivery():
+    mail = get_mock_email()
+    delivery = {
+        "timestamp": "2021-01-26T14:38:39.270Z",
+        "processingTimeMillis": 1796,
+        "recipients": ["recipient1@example.com"],
+        "smtpResponse": "",
+        "reportingMTA": ""
+    }
+    message = {
+        "eventType": "Delivery",
+        "mail": mail,
+        "delivery": delivery,
+    }
+    notification = get_mock_notification(message)
+    return mail, delivery, notification
+
+
+def get_mock_open():
+    mail = get_mock_email()
+    open = {
+        "timestamp": "2021-01-26T14:38:52.115Z",
+        "userAgent": "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)",
+        "ipAddress": "11.111.11.111"
+    }
+    message = {
+        "eventType": "Open",
+        "mail": mail,
+        "open": open,
+    }
+    notification = get_mock_notification(message)
+    return mail, open, notification
+
+
+def get_mock_click():
+    mail = get_mock_email()
+    click = {
+        "timestamp": "2021-01-26T14:38:55.540Z",
+        "ipAddress": "11.111.11.111",
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Safari/605.1.15",
+        "link": "github.com/django-ses/django-ses",
+        "linkTags": None
+    }
+    message = {
+        "eventType": "Click",
+        "mail": mail,
+        "click": click,
+    }
+    notification = get_mock_notification(message)
+    return mail, click, notification
+
+
+class HandleBounceTestCase(TestCase):
     """
     Test the bounce web hook handler.
     """
@@ -30,69 +160,147 @@ class HandleBounceTest(TestCase):
         """
         Test handling a normal bounce request.
         """
-        req_mail_obj = {
-            "timestamp": "2012-05-25T14:59:38.623-07:00",
-            "messageId": "000001378603177f-7a5433e7-8edb-42ae-af10-f0181f34d6ee-000000",
-            "source": "sender@example.com",
-            "destination": [
-                "recipient1@example.com",
-                "recipient2@example.com",
-                "recipient3@example.com",
-                "recipient4@example.com"
-            ]
-        }
-        req_bounce_obj = {
-            'bounceType': 'Permanent',
-            'bounceSubType': 'General',
-            'bouncedRecipients': [
-                {
-                    "status": "5.0.0",
-                    "action": "failed",
-                    "diagnosticCode": "smtp; 550 user unknown",
-                    "emailAddress": "recipient1@example.com",
-                },
-                {
-                    "status": "4.0.0",
-                    "action": "delayed",
-                    "emailAddress": "recipient2@example.com",
-                }
-            ],
-            "reportingMTA": "example.com",
-            "timestamp": "2012-05-25T14:59:38.605-07:00",
-            "feedbackId": "000001378603176d-5a4b5ad9-6f30-4198-a8c3-b1eb0c270a1d-000000",
-        }
+        req_mail_obj, req_bounce_obj, notification = get_mock_bounce()
 
-        message_obj = {
-            'eventType': 'Bounce',
-            'mail': req_mail_obj,
-            'bounce': req_bounce_obj,
-        }
-
-        notification = {
-            "Type": "Notification",
-            "MessageId": "22b80b92-fdea-4c2c-8f9d-bdfb0c7bf324",
-            "TopicArn": "arn:aws:sns:us-east-1:123456789012:MyTopic",
-            "Subject": "AWS Notification Message",
-            "Message": json.dumps(message_obj),
-            "Timestamp": "2012-05-02T00:54:06.655Z",
-            "SignatureVersion": "1",
-            "Signature": "",
-            "SigningCertURL": "",
-            "UnsubscribeURL": ""
-        }
-
-        def _handler(sender, mail_obj, bounce_obj, **kwargs):
-            _handler.called = True
-            self.assertEqual(req_mail_obj, mail_obj)
-            self.assertEqual(req_bounce_obj, bounce_obj)
-        _handler.called = False
+        _handler = MagicMock()
         bounce_received.connect(_handler)
 
         # Mock the verification
-        with mock.patch.object(ses_utils, 'verify_bounce_message') as verify:
+        with mock.patch.object(ses_utils, "verify_event_message") as verify:
             verify.return_value = True
 
-            self.client.post(reverse('django_ses_bounce'),
-                             json.dumps(notification), content_type='application/json')
+            self.client.post(reverse("django_ses_bounce"), json.dumps(notification), content_type="application/json")
 
-        self.assertTrue(_handler.called)
+        _handler.assert_called_once_with(
+            signal=ANY,
+            sender=handle_bounce,
+            mail_obj=req_mail_obj,
+            bounce_obj=req_bounce_obj,
+            raw_message=ANY,
+        )
+
+
+class HandleEventTestCase(TestCase):
+    """
+    Test the event web hook handler.
+    """
+    def setUp(self):
+        self._old_bounce_receivers = bounce_received.receivers
+        bounce_received.receivers = []
+
+        self._old_complaint_receivers = complaint_received.receivers
+        complaint_received.receivers = []
+
+    def tearDown(self):
+        bounce_received.receivers = self._old_bounce_receivers
+        complaint_received.receivers = self._old_complaint_receivers
+
+    def test_handle_bounce_event(self):
+        """
+        Test handling a normal bounce request.
+        """
+        req_mail_obj, req_bounce_obj, notification = get_mock_bounce()
+
+        _handler = MagicMock()
+        bounce_received.connect(_handler)
+
+        # Mock the verification
+        with mock.patch.object(ses_utils, "verify_event_message") as verify:
+            verify.return_value = True
+            self.client.post(reverse("django_ses_event"), json.dumps(notification), content_type="application/json")
+
+        _handler.assert_called_once_with(
+            signal=ANY,
+            sender=handle_event,
+            mail_obj=req_mail_obj,
+            bounce_obj=req_bounce_obj,
+            raw_message=ANY,
+        )
+
+    def test_handle_send_event(self):
+        """
+        Test handling a send event request.
+        """
+        req_mail_obj, req_send_obj, notification = get_mock_send()
+
+        _handler = MagicMock()
+        send_received.connect(_handler)
+
+        # Mock the verification
+        with mock.patch.object(ses_utils, "verify_event_message") as verify:
+            verify.return_value = True
+            self.client.post(reverse("django_ses_event"), json.dumps(notification), content_type="application/json")
+
+        _handler.assert_called_once_with(
+            signal=ANY,
+            sender=handle_event,
+            mail_obj=req_mail_obj,
+            send_obj=req_send_obj,
+            raw_message=ANY,
+        )
+
+    def test_handle_delivery_event(self):
+        """
+        Test handling a delivery event request.
+        """
+        req_mail_obj, req_delivery_obj, notification = get_mock_delivery()
+
+        _handler = MagicMock()
+        delivery_received.connect(_handler)
+
+        # Mock the verification
+        with mock.patch.object(ses_utils, "verify_event_message") as verify:
+            verify.return_value = True
+            self.client.post(reverse("django_ses_event"), json.dumps(notification), content_type="application/json")
+
+        _handler.assert_called_once_with(
+            signal=ANY,
+            sender=handle_event,
+            mail_obj=req_mail_obj,
+            delivery_obj=req_delivery_obj,
+            raw_message=ANY,
+        )
+
+    def test_handle_open_event(self):
+        """
+        Test handling a open event request.
+        """
+        req_mail_obj, req_open_obj, notification = get_mock_open()
+
+        _handler = MagicMock()
+        open_received.connect(_handler)
+
+        # Mock the verification
+        with mock.patch.object(ses_utils, "verify_event_message") as verify:
+            verify.return_value = True
+            self.client.post(reverse("django_ses_event"), json.dumps(notification), content_type="application/json")
+
+        _handler.assert_called_once_with(
+            signal=ANY,
+            sender=handle_event,
+            mail_obj=req_mail_obj,
+            open_obj=req_open_obj,
+            raw_message=ANY,
+        )
+
+    def test_handle_click_event(self):
+        """
+        Test handling a click event request.
+        """
+        req_mail_obj, req_click_obj, notification = get_mock_click()
+
+        _handler = MagicMock()
+        click_received.connect(_handler)
+
+        # Mock the verification
+        with mock.patch.object(ses_utils, "verify_event_message") as verify:
+            verify.return_value = True
+            self.client.post(reverse("django_ses_event"), json.dumps(notification), content_type="application/json")
+
+        _handler.assert_called_once_with(
+            signal=ANY,
+            sender=handle_event,
+            mail_obj=req_mail_obj,
+            click_obj=req_click_obj,
+            raw_message=ANY,
+        )


### PR DESCRIPTION
Adds support for `send`, `open` and `click` events. https://github.com/django-ses/django-ses/issues/144

`Event publishing` method supports these events. ([AWS SES Docs](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/monitor-sending-activity.html))

- handle send, open and click events
- add send_received, open_received, click_received signals
- add handle_event view (with bakcward support to handle_bounce)