### PR TITLE
Updated README for AWS_SES_VERIFY_EVENT_SIGNATURES

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -448,7 +448,7 @@ Full List of Settings
   need to publish your public key on DNS; the selector is set to ``ses`` by
   default.  See http://dkim.org/ for further detail.
 
-``VERIFY_EVENT_SIGNATURES``, ``VERIFY_BOUNCE_SIGNATURES``
+``AWS_SES_VERIFY_EVENT_SIGNATURES``, ``AWS_SES_VERIFY_BOUNCE_SIGNATURES``
   Optional. Default is True. Verify the contents of the message by matching the signature
   you recreated from the message contents with the signature that Amazon SNS sent with the message.
   See https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html for further detail.


### PR DESCRIPTION
The README previously suggested to set VERIFY_EVENT_SIGNATURES and VERIFY_BOUNCE_SIGNATURES to False not bother with verifying signatures (useful when you are not able to install the M2Crypto package). Digging into the code shows these settings should be AWS_SES_VERIFY_EVENT_SIGNATURES and AWS_SES_VERIFY_BOUNCE_SIGNATURES instead.