### PR TITLE
Adding django3.1 and 3.2 in tox matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,18 @@ env:
 
 matrix:
     exclude:
+    - python: 3.4
+      env: TOXENV=django111
+    - python: 3.5
+      env: TOXENV=django111
+    - python: 3.6
+      env: TOXENV=django111
+    - python: 3.7
+      env: TOXENV=django111
     - python: 3.8
       env: TOXENV=django111
     - python: 2.7
       env: TOXENV=django20
-    - python: 3.4
-      env: TOXENV=django20
-    - python: 3.5
-      env: TOXENV=django20
     - python: 3.8
       env: TOXENV=django20
     - python: 2.7
@@ -47,18 +51,14 @@ matrix:
       env: TOXENV=django30
     - python: 2.7
       env: TOXENV=django31
+    - python: 3.4
+      env: TOXENV=django31
+    - python: 3.5
+      env: TOXENV=django31
     - python: 2.7
       env: TOXENV=django32
     - python: 3.4
-      env: TOXENV=django30
-    - python: 3.4
-      env: TOXENV=django31
-    - python: 3.4
       env: TOXENV=django32
-    - python: 3.5
-      env: TOXENV=django30
-    - python: 3.5
-      env: TOXENV=django31
     - python: 3.5
       env: TOXENV=django32
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ env:
     - TOXENV=django21
     - TOXENV=django22
     - TOXENV=django30
+    - TOXENV=django31
+    - TOXENV=django32
+
 matrix:
     exclude:
     - python: 3.8
@@ -42,6 +45,22 @@ matrix:
       env: TOXENV=django30
     - python: 3.5
       env: TOXENV=django30
+    - python: 2.7
+      env: TOXENV=django31
+    - python: 2.7
+      env: TOXENV=django32
+    - python: 3.4
+      env: TOXENV=django30
+    - python: 3.4
+      env: TOXENV=django31
+    - python: 3.4
+      env: TOXENV=django32
+    - python: 3.5
+      env: TOXENV=django30
+    - python: 3.5
+      env: TOXENV=django31
+    - python: 3.5
+      env: TOXENV=django32
 
 before_install:
     - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -128,12 +128,17 @@ CLASSIFIERS = [
     'Framework :: Django :: 2.0',
     'Framework :: Django :: 2.1',
     'Framework :: Django :: 2.2',
+    'Framework :: Django :: 3.0',
+    'Framework :: Django :: 3.1',
+    'Framework :: Django :: 3.2',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{111,20,21,22,30}
+envlist = django{111,20,21,22,30,31,32}
 
 [testenv]
 commands =
@@ -11,6 +11,8 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2a1,<3.0
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
+    django31: Django>=3.2,<3.3
 # Per https://github.com/travis-ci/travis-ci/issues/7940, the Travis CI
 # image for trusty has a problem with its /etc/boto.cfg. Because tox
 # isolates environments, we specify the BOTO_CONFIG env var here:

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     django22: Django>=2.2a1,<3.0
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
-    django31: Django>=3.2,<3.3
+    django32: Django>=3.2,<3.3
 # Per https://github.com/travis-ci/travis-ci/issues/7940, the Travis CI
 # image for trusty has a problem with its /etc/boto.cfg. Because tox
 # isolates environments, we specify the BOTO_CONFIG env var here:


### PR DESCRIPTION
Adding django3.1 and 3.2 in tox matrix.  Remove un-supported combinations.

```
Django version | Python versions
-- | --
Django 2.1 supports Python 3.5, 3.6, and 3.7. Django 2.0 is the last version to support Python 3.4.

2.2 | 3.5, 3.6, 3.7, 3.8 (added in 2.2.8), 3.9 (added in 2.2.17)
3.0 | 3.6, 3.7, 3.8, 3.9 (added in 3.0.11)
3.1 | 3.6, 3.7, 3.8, 3.9 (added in 3.1.3)
3.2 | 3.6, 3.7, 3.8, 3.9
4.0 | 3.8, 3.9, 3.10
````

Django3.2 tests execution shows 1 warning and its mentioned in[ release notes](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys).
```
django_ses.SESStat: (models.W042) Auto-created primary key used when not defining a primary key type,
 by default 'django.db.models.AutoField'.
HINT: Configure the DEFAULT_AUTO_FIELD setting or the DjangoSESConfig.default_auto_field attribute
 to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

**NOTE: Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.**