### PR TITLE
Migration to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,96 @@
+name: Unit tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Python ${{ matrix.python-version }}, django ${{ matrix.django-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9]
+        django-version: [111, 22, 30, 31, 32]
+
+        exclude:
+          - python-version: 2.7
+            django-version: 22
+
+          - python-version: 2.7
+            django-version: 30
+
+          - python-version: 2.7
+            django-version: 31
+
+          - python-version: 2.7
+            django-version: 32
+
+          - python-version: 3.4
+            django-version: 22
+
+          - python-version: 3.4
+            django-version: 30
+
+          - python-version: 3.4
+            django-version: 31
+
+          - python-version: 3.4
+            django-version: 32
+
+          - python-version: 3.5
+            django-version: 30
+
+          - python-version: 3.5
+            django-version: 31
+
+          - python-version: 3.5
+            django-version: 32
+
+          - python-version: 3.6
+            django-version: 111
+
+          - python-version: 3.6
+            django-version: 20
+
+          - python-version: 3.7
+            django-version: 111
+
+          - python-version: 3.7
+            django-version: 20
+
+          - python-version: 3.8
+            django-version: 111
+
+          - python-version: 3.8
+            django-version: 20
+
+          - python-version: 3.8
+            django-version: 21
+
+          - python-version: 3.8
+            django-version: 22
+
+          - python-version: 3.9
+            django-version: 111
+
+          - python-version: 3.9
+            django-version: 20
+
+          - python-version: 3.9
+            django-version: 21
+
+          - python-version: 3.9
+            django-version: 22
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install tox
+        run: pip install tox
+      - name: Run Tests
+        env:
+          TOXENV: django${{ matrix.django-version }}
+        run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Python ${{ matrix.python-version }}, django ${{ matrix.django-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9]
@@ -87,7 +87,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install tox
         run: pip install tox
       - name: Run Tests

--- a/setup.py
+++ b/setup.py
@@ -128,12 +128,18 @@ CLASSIFIERS = [
     'Framework :: Django :: 2.0',
     'Framework :: Django :: 2.1',
     'Framework :: Django :: 2.2',
+    'Framework :: Django :: 3.0',
+    'Framework :: Django :: 3.1',
+    'Framework :: Django :: 3.2',
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django{111,20,21,22,30}
+envlist = django{111,20,21,22,30,31,32}
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ deps =
     django21: Django>=2.1,<2.2
     django22: Django>=2.2a1,<3.0
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
 # Per https://github.com/travis-ci/travis-ci/issues/7940, the Travis CI
 # image for trusty has a problem with its /etc/boto.cfg. Because tox
 # isolates environments, we specify the BOTO_CONFIG env var here:


### PR DESCRIPTION
Adding django3.1 and 3.2 in tox matrix.  Remove un-supported combinations.
Moving to github actions

```
Django version | Python versions
-- | --
Django 2.1 supports Python 3.5, 3.6, and 3.7. Django 2.0 is the last version to support Python 3.4.

2.2 | 3.5, 3.6, 3.7, 3.8 (added in 2.2.8), 3.9 (added in 2.2.17)
3.0 | 3.6, 3.7, 3.8, 3.9 (added in 3.0.11)
3.1 | 3.6, 3.7, 3.8, 3.9 (added in 3.1.3)
3.2 | 3.6, 3.7, 3.8, 3.9
4.0 | 3.8, 3.9, 3.10
````

Django3.2 tests execution shows 1 warning and its mentioned in[ release notes](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys).
```
django_ses.SESStat: (models.W042) Auto-created primary key used when not defining a primary key type,
 by default 'django.db.models.AutoField'.
HINT: Configure the DEFAULT_AUTO_FIELD setting or the DjangoSESConfig.default_auto_field attribute
 to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
```

**NOTE: Since June 15th, 2021, the building on travis-ci.org is ceased. Please use travis-ci.com from now on.**