### PR TITLE
Add SES identity owners or "use verified SES-domains across accounts"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -311,6 +311,23 @@ Example DNS record published to Route53 with boto:
 .. _DomainKeys: http://dkim.org/
 
 
+Identity Owners
+===============
+
+With Identity owners, you can use validated SES-domains across multiple accounts:
+https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html
+
+This is useful if you got multiple environments in different accounts and still want to send mails via the same domain.
+
+You can configure the following environment variables to use them as described in boto3-docs_::
+
+    AWS_SES_SOURCE_ARN=arn:aws:ses:eu-central-1:012345678910:identity/example.com
+    AWS_SES_FROM_ARN=arn:aws:ses:eu-central-1:012345678910:identity/example.com
+    AWS_SES_RETURN_PATH_ARN=arn:aws:ses:eu-central-1:012345678910:identity/example.com
+
+.. _boto3-docs: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html#SES.Client.send_raw_email
+
+
 SES Sending Stats
 =================
 
@@ -452,6 +469,18 @@ Full List of Settings
   then email messages will be signed with the specified key.   You will also
   need to publish your public key on DNS; the selector is set to ``ses`` by
   default.  See http://dkim.org/ for further detail.
+
+``AWS_SES_SOURCE_ARN``
+  Instruct Amazon SES to use a domain from another account.
+  For more information please refer to https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html
+
+``AWS_SES_FROM_ARN``
+  Instruct Amazon SES to use a domain from another account.
+  For more information please refer to https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html
+
+``AWS_SES_RETURN_PATH_ARN``
+  Instruct Amazon SES to use a domain from another account.
+  For more information please refer to https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html
 
 ``AWS_SES_VERIFY_EVENT_SIGNATURES``, ``AWS_SES_VERIFY_BOUNCE_SIGNATURES``
   Optional. Default is True. Verify the contents of the message by matching the signature

--- a/django_ses/settings.py
+++ b/django_ses/settings.py
@@ -30,6 +30,10 @@ DKIM_SELECTOR = getattr(settings, 'DKIM_SELECTOR', 'ses')
 DKIM_HEADERS = getattr(settings, 'DKIM_HEADERS',
                        ('From', 'To', 'Cc', 'Subject'))
 
+AWS_SES_SOURCE_ARN = getattr(settings, 'AWS_SES_SOURCE_ARN', None)
+AWS_SES_FROM_ARN = getattr(settings, 'AWS_SES_FROM_ARN', None)
+AWS_SES_RETURN_PATH_ARN = getattr(settings, 'AWS_SES_RETURN_PATH_ARN', None)
+
 TIME_ZONE = settings.TIME_ZONE
 
 VERIFY_EVENT_SIGNATURES = getattr(settings, 'AWS_SES_VERIFY_EVENT_SIGNATURES',

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -201,7 +201,7 @@ class SESBackendTest(TestCase):
 
     def test_source_arn_is_NOT_set(self):
         """
-        Ensure that the helpers for Identity Owner for SES Sending Authorization are None, if nothing has been
+        Ensure that the helpers for Identity Owner for SES Sending Authorization are not present, if nothing has been
         configured.
         """
         send_mail('subject', 'body', 'from@example.com', ['to@example.com'])

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -186,6 +186,30 @@ class SESBackendTest(TestCase):
         send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
         self.assertEqual(self.outbox.pop()['Source'], 'from@example.com')
 
+    def test_source_arn_is_set(self):
+        """
+        Ensure that the helpers for Identity Owner for SES Sending Authorization are set correctly.
+        """
+        settings.AWS_SES_SOURCE_ARN = 'arn:aws:ses:eu-central-1:111111111111:identity/example.com'
+        settings.AWS_SES_FROM_ARN = 'arn:aws:ses:eu-central-1:222222222222:identity/example.com'
+        settings.AWS_SES_RETURN_PATH_ARN = 'arn:aws:ses:eu-central-1:333333333333:identity/example.com'
+        send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+        mail = self.outbox.pop()
+        self.assertEqual(mail['SourceArn'], 'arn:aws:ses:eu-central-1:111111111111:identity/example.com')
+        self.assertEqual(mail['FromArn'], 'arn:aws:ses:eu-central-1:222222222222:identity/example.com')
+        self.assertEqual(mail['ReturnPathArn'], 'arn:aws:ses:eu-central-1:333333333333:identity/example.com')
+
+    def test_source_arn_is_NOT_set(self):
+        """
+        Ensure that the helpers for Identity Owner for SES Sending Authorization are None, if nothing has been
+        configured.
+        """
+        send_mail('subject', 'body', 'from@example.com', ['to@example.com'])
+        mail = self.outbox.pop()
+        self.assertNotIn('SourceArn', mail)
+        self.assertNotIn('FromArn', mail)
+        self.assertNotIn('ReturnPathArn', mail)
+
 
 class SESBackendTestReturn(TestCase):
     def setUp(self):


### PR DESCRIPTION
# User Story
As devops-engineer I want to separate my environments from each other to keep my applications as secure as possible, as described in [AWS best practices](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/aws-account-management-and-separation.html). I do _not_ want to validate my SES-domains in all accounts, but I want to use "identity owners" to send mails from multiple accounts via **one** SES-domain: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization-delegate-sender-tasks-email.html

The result is: I have a lot of environments (PROD, TEST, STAGE, ...), which can send SES-mails from my one "SES-core-account", which contains my validated domains.

# Solution
Identity Owners and Delegate Senders can do that:

> As a delegate sender, you send emails the same way that other Amazon SES senders do, except that you provide the ARN of the identity that the identity owner has authorized you to use. When you call Amazon SES to send the email, Amazon SES checks to see if the identity that you specified has a policy that authorizes you to send for it.

This pull requests includes the changes described in https://github.com/django-ses/django-ses/issues/227

fixes #227