### PR TITLE
Remove future from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     platforms=['any'],
     classifiers=CLASSIFIERS,
-    install_requires=["boto3>=1.0.0", "pytz>=2016.10", "future>=0.16.0", "django>=2.2"],
+    install_requires=["boto3>=1.0.0", "pytz>=2016.10", "django>=2.2"],
     include_package_data=True,
     extras_require={
         'bounce': ['requests<3', 'M2Crypto'],


### PR DESCRIPTION
Since now the projects has fully moved to python 3 the [future](https://pypi.org/project/future/) package is no more required as a dependency.