### PR TITLE
Update the notification type key

### DIFF
--- a/django_ses/views.py
+++ b/django_ses/views.py
@@ -287,7 +287,7 @@ def handle_bounce(request):
             })
         else:
             mail_obj = message.get('mail')
-            event_type = message.get('eventType')
+            event_type = message.get('notificationType')
 
             if event_type == 'Bounce':
                 # Bounce
@@ -441,7 +441,7 @@ class SESEventWebhookView(View):
                     'notification': notification,
                 })
             else:
-                event_type = message.get('eventType')
+                event_type = message.get('notificationType')
                 if event_type == 'Bounce':
                     self.handle_bounce(notification, message)
                 elif event_type == 'Complaint':

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -66,7 +66,7 @@ def get_mock_bounce():
     }
 
     message = {
-        "eventType": "Bounce",
+        "notificationType": "Bounce",
         "mail": mail,
         "bounce": bounce,
     }
@@ -78,7 +78,7 @@ def get_mock_send():
     mail = get_mock_email()
     send = {}
     message = {
-        "eventType": "Send",
+        "notificationType": "Send",
         "mail": mail,
         "send": send,
     }
@@ -96,7 +96,7 @@ def get_mock_delivery():
         "reportingMTA": ""
     }
     message = {
-        "eventType": "Delivery",
+        "notificationType": "Delivery",
         "mail": mail,
         "delivery": delivery,
     }
@@ -112,7 +112,7 @@ def get_mock_open():
         "ipAddress": "11.111.11.111"
     }
     message = {
-        "eventType": "Open",
+        "notificationType": "Open",
         "mail": mail,
         "open": open,
     }
@@ -130,7 +130,7 @@ def get_mock_click():
         "linkTags": None
     }
     message = {
-        "eventType": "Click",
+        "notificationType": "Click",
         "mail": mail,
         "click": click,
     }


### PR DESCRIPTION
Incoming payload from AWS SNS contains a message, which is a
JSON string.
This message used to have as a key "eventType" to designate if the event
was a Delivery or a Bounce for example.

The key no longer exists and is now "notificationType".

(Extracted from SNS payload) 
![image](https://user-images.githubusercontent.com/70256364/167661197-0f097328-b58e-440b-80fa-6b3a2cb4afd1.png)

This leads every notification sent to fall in the "unknown event type"
case in SNSEventWebhookView.

https://github.com/django-ses/django-ses/blob/f9eb643f8f7ba757f13305ab7fb2c2705712a5ed/django_ses/views.py#L444-L458

Closes #247