### PR TITLE
use regionname in endpoint url instead of static value

### DIFF
--- a/django_ses/settings.py
+++ b/django_ses/settings.py
@@ -15,7 +15,7 @@ SECRET_KEY = getattr(settings, 'AWS_SES_SECRET_ACCESS_KEY',
 AWS_SES_REGION_NAME = getattr(settings, 'AWS_SES_REGION_NAME',
                               getattr(settings, 'AWS_DEFAULT_REGION', 'us-east-1'))
 AWS_SES_REGION_ENDPOINT = getattr(settings, 'AWS_SES_REGION_ENDPOINT',
-                                  'email.us-east-1.amazonaws.com')
+                                  f'email.{AWS_SES_REGION_NAME}.amazonaws.com')
 AWS_SES_REGION_ENDPOINT_URL = getattr(settings, 'AWS_SES_REGION_ENDPOINT_URL',
                                       'https://' + AWS_SES_REGION_ENDPOINT)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,3 +25,16 @@ class SettingsImportTest(TestCase):
         unload_django_ses()
         import django_ses
         self.assertEqual(django_ses.settings.AWS_SES_CONFIGURATION_SET, settings.AWS_SES_CONFIGURATION_SET)
+
+    def test_ses_region_to_endpoint_default_given(self):
+        unload_django_ses()
+        import django_ses
+        self.assertEqual(django_ses.settings.AWS_SES_REGION_NAME, 'us-east-1')
+        self.assertEqual(django_ses.settings.AWS_SES_REGION_ENDPOINT, f'email.{django_ses.settings.AWS_SES_REGION_NAME}.amazonaws.com')
+
+    def test_ses_region_to_endpoint_set_given(self):
+        settings.AWS_SES_REGION_NAME = 'eu-west-1'
+        unload_django_ses()
+        import django_ses
+        self.assertEqual(django_ses.settings.AWS_SES_REGION_NAME, settings.AWS_SES_REGION_NAME)
+        self.assertEqual(django_ses.settings.AWS_SES_REGION_ENDPOINT, f'email.{settings.AWS_SES_REGION_NAME}.amazonaws.com')

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -36,5 +36,5 @@ class SettingsImportTest(TestCase):
         settings.AWS_SES_REGION_NAME = 'eu-west-1'
         unload_django_ses()
         import django_ses
-        self.assertEqual(django_ses.settings.AWS_SES_REGION_NAME, settings.AWS_SES_REGION_NAME)
-        self.assertEqual(django_ses.settings.AWS_SES_REGION_ENDPOINT, f'email.{settings.AWS_SES_REGION_NAME}.amazonaws.com')
+        self.assertEqual(django_ses.settings.AWS_SES_REGION_NAME, 'eu-west-1')
+        self.assertEqual(django_ses.settings.AWS_SES_REGION_ENDPOINT, 'email.eu-west-1.amazonaws.com')


### PR DESCRIPTION
The readme states to change `REGION` as well as `ENDPOINT` if not using `us-east-1` for region. This change uses the `AWS_SES_REGION_NAME` in `AWS_SES_REGION_ENDPOINT` instead of static value i.e. will use `mail.{AWS_SES_REGION_NAME}.amazonaws.com` instead of `mail.us-east-1.amazonaws.com` even if it is not set.
Just a small ease in my opinion.