### PR TITLE
Handle potential notificationType in bounce and complaint events

### DIFF
--- a/django_ses/views.py
+++ b/django_ses/views.py
@@ -289,7 +289,7 @@ def handle_bounce(request):
             })
         else:
             mail_obj = message.get('mail')
-            event_type = message.get('eventType')
+            event_type = message.get('eventType', message.get('notificationType'))
 
             if event_type == 'Bounce':
                 # Bounce
@@ -381,7 +381,7 @@ class SESEventWebhookView(View):
     Handle a email sending event via an SNS webhook.
 
     Parse the event message and send the appropriate signal.
-    <eventType> -> <signal>
+    <eventType|notificationType> -> <signal>  (preferring eventType)
     bounce -> bounce_received
     complaint -> complaint_received
     delivery -> delivery_received
@@ -443,7 +443,7 @@ class SESEventWebhookView(View):
                     'notification': notification,
                 })
             else:
-                event_type = message.get('eventType')
+                event_type = message.get('eventType', message.get('notificationType'))
                 if event_type == 'Bounce':
                     self.handle_bounce(notification, message)
                 elif event_type == 'Complaint':


### PR DESCRIPTION
According to the official docs[^1] the top level key is either `eventType` or `notificationType`, depending on whether or not users have configured event publishing.

The current docs for django-ses recommend setting up a configuration set and event publishing, but as mentioned in #248, it's possible to use django-ses with the less-complete notification system.

This PR changes django-ses to handle either `notificationType` or `eventType`, preferring the current `eventType` if it exists.

Resolves #174.

[^1]: https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html#top-level-json-object