### PR TITLE
Fixed bug with missing raw string for regex

### DIFF
--- a/django_ses/utils.py
+++ b/django_ses/utils.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 _CERT_CACHE = {}
 
 SES_REGEX_CERT_URL = re.compile(
-    "(?i)^https://sns\.[a-z0-9\-]+\.amazonaws\.com(\.cn)?/SimpleNotificationService\-[a-z0-9]+\.pem$"
+    r"(?i)^https://sns\.[a-z0-9\-]+\.amazonaws\.com(\.cn)?/SimpleNotificationService\-[a-z0-9]+\.pem$"
 )
 
 


### PR DESCRIPTION
Hi @pcraciunoiu!

I get this error in my console:

> C:\Users\...\virtualenvs\ai-compliance-qfB4aKIw-py3.12\Lib\site-packages\django_ses\utils.py:20: SyntaxWarning: invalid escape sequence '\.'
>   "(?i)^https://sns\.[a-z0-9\-]+\.amazonaws\.com(\.cn)?/SimpleNotificationService\-[a-z0-9]+\.pem$"

Converting the regex expression to a raw string fixes that error.

What do you thing?

Best from Cologne  
Ronny