### PR TITLE
Update README to include IAM policy details for SES stats

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -342,6 +342,17 @@ Django SES comes with two ways of viewing sending statistics.
 The first one is a simple read-only report on your 24 hour sending quota,
 verified email addresses and bi-weekly sending statistics.
 
+To enable the dashboard to retrieve data from AWS, you need to update the IAM policy by adding the following actions::
+
+    {
+        "Effect": "Allow",
+        "Action": [
+            "ses:ListVerifiedEmailAddresses",
+            "ses:GetSendStatistics"
+        ],
+        "Resource": "*"
+    }
+
 To generate and view SES sending statistics reports, include, update
 ``INSTALLED_APPS``::
 


### PR DESCRIPTION
Added 2 actions that need to be added to the user's IAM policy to enable the dashboard to retrieve the data from AWS.
Users will get an error without those permissions so I believe they should be included in the docs.