### PR TITLE
Fix wrong (deprecated) url mapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,11 +113,12 @@ To set this up, install `django-ses` with the `events` extra::
 
 Then add a event url handler in your `urls.py`::
 
+    from django.urls import re_path
     from django_ses.views import SESEventWebhookView
     from django.views.decorators.csrf import csrf_exempt
     urlpatterns = [ ...
-                    url(r'^ses/event-webhook/$', SESEventWebhookView.as_view(), name='handle-event-webhook'),
-                    ...
+            re_path(r'^ses/event-webhook/$', SESEventWebhookView.as_view(), name='handle-event-webhook'),
+            ...
     ]
 
 SESEventWebhookView handles bounce, complaint, send, delivery, open and click events.


### PR DESCRIPTION
This is a small fix in the README