### PR TITLE
docs: add missing open_obj and click_obj

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ Using signal 'open_received' for manager open email. For example::
 
 
     @receiver(open_received)
-    def open_handler(sender, mail_obj, raw_message, *args, **kwargs):
+    def open_handler(sender, mail_obj, open_obj, raw_message, *args, **kwargs):
         ...
 
 Click
@@ -220,7 +220,7 @@ Using signal 'click_received' for manager send email. For example::
 
 
     @receiver(click_received)
-    def click_handler(sender, mail_obj, raw_message, *args, **kwargs):
+    def click_handler(sender, mail_obj, click_obj, raw_message, *args, **kwargs):
         ...
 
 Testing Signals


### PR DESCRIPTION
This PR add missing `open_obj` and `click_obj` parameter to the open and click signal receiver. 

In the code implemntation, there is `open_obj` and `click_obj` but docs did not mentioned it.
https://github.com/RoRep1ay/django-ses/blob/main/django_ses/views.py#L540-L560

Also, it was initally included but was removed later on.
https://github.com/django-ses/django-ses/pull/224/files
