### PR TITLE
Continue if all recipients are blacklisted

### DIFF
--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -141,7 +141,7 @@ class SESBackend(BaseEmailBackend):
 
                 if len(message.to) + len(message.cc) + len(message.bcc) == 0:
                     logger.debug('Refusing to send email. All recipients were filtered by the blacklist')
-                    return
+                    continue
 
             # SES Configuration sets. If the AWS_SES_CONFIGURATION_SET setting
             # is not None, append the appropriate header to the message so that


### PR DESCRIPTION
This fixes an issue in `SESBackend.send_messages()` where it would abort sending all remaining messages if any single message has all recipients blacklisted.

Instead of aborting, it should continue with the next message.