### PR TITLE
Fix LocalStack CI; align Poetry Django bounds with tox matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
 
     services:
       localstack:
-        image: localstack/localstack:latest
+        # Pin a release image so CI does not break when :latest changes. The image
+        # ships its own HTTP healthcheck; avoid awslocal-based checks — newer
+        # LocalStack can lazy-load SES so SES CLI probes fail during startup.
+        image: localstack/localstack:3.8
         env:
           SERVICES: ses
           DEBUG: 1
@@ -37,16 +40,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: test
         ports:
           - 4566:4566
-        options: >-
-          --health-cmd "awslocal ses list-identities || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
     strategy:
       matrix:
         python-version: ["3.14", "3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
-        django-version: [32, 42, 52, 60]
+        # 60 first: default / newest tested combo where Python allows (Django 6 needs 3.12+).
+        django-version: [60, 52, 42, 32]
         exclude:
           - python-version: "3.13"
             django-version: 32

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ description = "ASGI specs, helper code, and adapters"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47"},
     {file = "asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"},
@@ -75,7 +75,7 @@ description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "boto3-1.37.38-py3-none-any.whl", hash = "sha256:b6d42803607148804dff82389757827a24ce9271f0583748853934c86310999f"},
     {file = "boto3-1.37.38.tar.gz", hash = "sha256:88c02910933ab7777597d1ca7c62375f52822e0aa1a8e0c51b2598a547af42b2"},
@@ -117,7 +117,7 @@ description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "botocore-1.37.38-py3-none-any.whl", hash = "sha256:23b4097780e156a4dcaadfc1ed156ce25cb95b6087d010c4bb7f7f5d9bc9d219"},
     {file = "botocore-1.37.38.tar.gz", hash = "sha256:c3ea386177171f2259b284db6afc971c959ec103fa2115911c4368bea7cbbc5d"},
@@ -162,7 +162,7 @@ description = "Extensible memoizing collections and decorators"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
     {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
@@ -393,7 +393,7 @@ description = "Validate configuration and produce human readable error messages.
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
@@ -419,7 +419,7 @@ description = "Universal encoding detector for Python 3"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
     {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
@@ -708,7 +708,7 @@ description = "A high-level Python web framework that encourages rapid developme
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "django-4.2.29-py3-none-any.whl", hash = "sha256:074d7c4d2808050e528388bda442bd491f06def4df4fe863f27066851bba010c"},
     {file = "django-4.2.29.tar.gz", hash = "sha256:86d91bc8086569c8d08f9c55888b583a921ac1f95ed3bdc7d5659d4709542014"},
@@ -753,7 +753,7 @@ description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
     {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
@@ -797,7 +797,7 @@ description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "identify-2.6.1-py2.py3-none-any.whl", hash = "sha256:53863bcac7caf8d2ed85bd20312ea5dcfc22226800f6d6881f232d861db5a8f0"},
     {file = "identify-2.6.1.tar.gz", hash = "sha256:91478c5fb7c3aac5ff7bf9b4344f803843dc586832d5f110d672b19aa1984c98"},
@@ -861,7 +861,7 @@ description = "JSON Matching Expressions"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
     {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
@@ -911,7 +911,7 @@ description = "A small Python package for determining appropriate platform-speci
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
     {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
@@ -960,7 +960,7 @@ description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -994,7 +994,7 @@ description = "A framework for managing and maintaining multi-language pre-commi
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "pre_commit-3.5.0-py2.py3-none-any.whl", hash = "sha256:841dc9aef25daba9a0238cd27984041fa0467b4199fc4852e27950664919f660"},
     {file = "pre_commit-3.5.0.tar.gz", hash = "sha256:5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32"},
@@ -1080,7 +1080,7 @@ description = "API to interact with the python pyproject.toml based projects"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228"},
     {file = "pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496"},
@@ -1335,7 +1335,7 @@ description = "An Amazon S3 Transfer Manager"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "s3transfer-0.11.5-py3-none-any.whl", hash = "sha256:757af0f2ac150d3c75bc4177a32355c3862a98d20447b69a0161812992fe0bd4"},
     {file = "s3transfer-0.11.5.tar.gz", hash = "sha256:8c8aad92784779ab8688a61aefff3e28e9ebdce43142808eaa3f0b0f402f68b7"},
@@ -1401,7 +1401,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or python_version >= \"3.9\" and python_version <= \"3.10\" or platform_python_implementation == \"PyPy\" and python_version <= \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version <= \"3.10\" and python_version >= \"3.9\" or python_version <= \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867"},
     {file = "tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9"},
@@ -1459,7 +1459,7 @@ description = "tox is a generic virtualenv management and test command line tool
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "tox-4.25.0-py3-none-any.whl", hash = "sha256:4dfdc7ba2cc6fdc6688dde1b21e7b46ff6c41795fb54586c91a3533317b5255c"},
     {file = "tox-4.25.0.tar.gz", hash = "sha256:dd67f030317b80722cf52b246ff42aafd3ed27ddf331c415612d084304cf5e52"},
@@ -1542,7 +1542,7 @@ description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "dev"]
-markers = "python_full_version == \"3.8.*\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
@@ -1581,7 +1581,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 groups = ["main"]
-markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or platform_python_implementation == \"PyPy\" and python_version < \"3.10\""
+markers = "python_full_version == \"3.8.*\" or python_version == \"3.9\" or python_version < \"3.10\" and platform_python_implementation == \"PyPy\""
 files = [
     {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
     {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
@@ -1640,4 +1640,4 @@ events = ["cryptography", "requests"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8"
-content-hash = "7341f2016efda956a7418e7c9613e7604fc7aee3867cc1f24039210ae4bb0e47"
+content-hash = "7036e2ef16887d44ee5df84f38490d1aaccc2e30ce073666c5fc1f5cc481a614"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ include = ["example", "tests"]
 [tool.poetry.dependencies]
 python = ">=3.8"
 boto3 = ">=1.0.0"
-# Intended majors: >=3.2,<4 | >=4,<5 | >=5,<6 | >=6,<7 (use >=4,<5 for Django 4.x, not >=4,<4).
+# Intended majors: >=3.2,<4 | >=4,<5 | >=5,<6 | >=6,<7
 # Poetry needs disjoint python markers; each row is one Python band and a union of
 # those major ranges where CI runs that combo.
 django = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,15 @@ include = ["example", "tests"]
 [tool.poetry.dependencies]
 python = ">=3.8"
 boto3 = ">=1.0.0"
-django = ">=3.2"
+# Intended majors: >=3.2,<4 | >=4,<5 | >=5,<6 | >=6,<7 (use >=4,<5 for Django 4.x, not >=4,<4).
+# Poetry needs disjoint python markers; each row is one Python band and a union of
+# those major ranges where CI runs that combo.
+django = [
+    {version = ">=3.2,<5", python = ">=3.8,<3.10"},
+    {version = ">=3.2,<6", python = ">=3.10,<3.12"},
+    {version = ">=3.2,<7", python = ">=3.12,<3.13"},
+    {version = ">=4,<7", python = ">=3.13"},
+]
 backports-zoneinfo = {version = ">=0.2.1", python = "<3.9"}
 cryptography = {version = ">=36.0.2", optional = true}
 requests = {version = ">=2.32.1", optional = true}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = django{32,42,52,60}
+envlist = django{60,52,42,32}
 
 [testenv]
 commands =


### PR DESCRIPTION
## Summary
- **CI:** Pin `localstack/localstack:3.8` and drop the custom `awslocal` service health check so the container can become healthy (lazy SES / CLI timing on newer `:latest` builds was failing **Initialize containers**).
- **Tox / CI matrix:** Keep Django 6 first in `envlist` / matrix ordering where supported.
- **Poetry:** Replace the single `django` constraint with disjoint `python_env` ranges that mirror the tox/CI-supported unions, and regenerate `poetry.lock`.

## Notes
- Poetry still resolves Django 5.2.x for Python ≥3.10 in the lockfile where that satisfies the declared upper bounds; Django 6 is not forced unless constraints require it (see discussion in prior review).


Made with [Cursor](https://cursor.com)