### PR TITLE
Add Django 6.1 support, including use as a MAILERS backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.14", "3.13", "3.12", "3.11", "3.10", "3.9", "3.8"]
-        # 60 first: default / newest tested combo where Python allows (Django 6 needs 3.12+).
-        django-version: [60, 52, 42, 32]
+        # 61 first: default / newest tested combo where Python allows (Django 6 needs 3.12+).
+        django-version: [61, 60, 52, 42, 32]
         exclude:
           - python-version: "3.13"
             django-version: 32
@@ -63,6 +63,14 @@ jobs:
             django-version: 60
           - python-version: "3.11"
             django-version: 60
+          - python-version: "3.8"
+            django-version: 61
+          - python-version: "3.9"
+            django-version: 61
+          - python-version: "3.10"
+            django-version: 61
+          - python-version: "3.11"
+            django-version: 61
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Pulls and Issues:
  - None
 
 Features:
-- None
+- Add support for Django 6.1, including use as a `MAILERS` backend.
 
 Changes:
 - None
@@ -19,7 +19,10 @@ Deprecations:
  - None
 
 Fixes:
-- None
+- `SESBackend` no longer forwards `fail_silently` to `BaseEmailBackend.__init__()`.
+  Django 6.1 removed that argument: forwarding it raised `InvalidMailer` when the
+  backend was instantiated from a `MAILERS` alias, and emitted a
+  `RemovedInDjango70Warning` otherwise.
 
 ## Current
 

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,29 @@ you would to upload files via S3::
 Now, when you use ``django.core.mail.send_mail``, Simple Email Service will
 send the messages by default.
 
+On Django 6.1+ you can instead use the ``MAILERS`` setting, which replaces
+``EMAIL_BACKEND`` in Django 7.0::
+
+    MAILERS = {
+        "default": {"BACKEND": "django_ses.SESBackend"},
+    }
+
+The ``AWS_*`` settings above are still read, so nothing else needs to change.
+Any ``SESBackend`` constructor argument may also be given per-mailer under
+``OPTIONS``::
+
+    MAILERS = {
+        "default": {
+            "BACKEND": "django_ses.SESBackend",
+            "OPTIONS": {"aws_region_name": "us-west-2"},
+        },
+    }
+
+Note that ``OPTIONS`` values are passed to ``SESBackend`` verbatim. In
+particular, ``aws_region_endpoint`` must include the scheme
+(``https://email.us-west-2.amazonaws.com``), whereas the
+``AWS_SES_REGION_ENDPOINT`` setting does not.
+
 Since SES imposes a rate limit and will reject emails after the limit has been
 reached, django-ses will attempt to conform to the rate limit by querying the
 API for your current limit and then sending no more than that number of

--- a/django_ses/__init__.py
+++ b/django_ses/__init__.py
@@ -107,7 +107,13 @@ class SESBackend(BaseEmailBackend):
         **kwargs,
     ):
 
-        super(SESBackend, self).__init__(fail_silently=fail_silently, **kwargs)
+        # Django 6.1+ removed ``fail_silently`` from ``BaseEmailBackend.__init__()``;
+        # a subclass that supports it must set the attribute itself. Forwarding it to
+        # ``super()`` raises ``InvalidMailer`` when instantiated from a ``MAILERS``
+        # alias, and warns ``RemovedInDjango70Warning`` otherwise. Setting it directly
+        # works on every supported Django version.
+        super(SESBackend, self).__init__(**kwargs)
+        self.fail_silently = fail_silently
         self._session_profile = aws_session_profile or settings.AWS_SESSION_PROFILE
         self._access_key_id = aws_access_key or settings.ACCESS_KEY
         self._access_key = aws_secret_key or settings.SECRET_KEY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     'Framework :: Django :: 4.2',
     'Framework :: Django :: 5.2',
     'Framework :: Django :: 6.0',
+    'Framework :: Django :: 6.1',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import email
+import unittest
+import warnings
 
+import django
 from django.core.mail import EmailMessage, send_mail
 from django.test import TestCase, override_settings
 from django.utils.encoding import smart_str
@@ -471,3 +474,46 @@ class GlobalEndpointDefaultTest(TestCase):
         # Verify EndpointId is NOT included when not configured
         params = FakeSESConnection.outbox[0]
         self.assertNotIn("EndpointId", params)
+
+
+@unittest.skipIf(django.VERSION < (6, 1), "MAILERS was added in Django 6.1")
+class MailersTest(TestCase):
+    """SESBackend must work as a Django 6.1+ MAILERS entry.
+
+    Django 6.1 dropped ``fail_silently`` from ``BaseEmailBackend.__init__()``.
+    A backend that still forwards it raises ``InvalidMailer`` when instantiated
+    from a ``MAILERS`` alias.
+    """
+
+    @override_settings(MAILERS={"default": {"BACKEND": "django_ses.SESBackend"}})
+    def test_instantiates_as_default_mailer(self):
+        from django.core.mail import mailers
+
+        backend = mailers["default"]
+        self.assertIsInstance(backend, django_ses.SESBackend)
+        self.assertEqual(backend.alias, "default")
+        self.assertFalse(backend.fail_silently)
+
+    @override_settings(
+        MAILERS={
+            "default": {
+                "BACKEND": "django_ses.SESBackend",
+                "OPTIONS": {"fail_silently": True, "aws_region_name": "eu-central-1"},
+            }
+        }
+    )
+    def test_options_are_applied(self):
+        from django.core.mail import mailers
+
+        backend = mailers["default"]
+        self.assertTrue(backend.fail_silently)
+        self.assertEqual(backend._region_name, "eu-central-1")
+
+    def test_no_deprecation_warning_from_legacy_settings(self):
+        from django.utils.deprecation import RemovedInDjango70Warning
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            django_ses.SESBackend()
+
+        self.assertEqual([w for w in caught if issubclass(w.category, RemovedInDjango70Warning)], [])

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = django{60,52,42,32}
+envlist = django{61,60,52,42,32}
 
 [testenv]
 commands =
@@ -12,6 +12,7 @@ deps =
     django42: Django>=4.2,<4.3
     django52: Django>=5.1,<5.3
     django60: Django>=6.0,<6.1
+    django61: Django>=6.1,<6.2
 
 # Per https://github.com/travis-ci/travis-ci/issues/7940, the Travis CI
 # image for trusty has a problem with its /etc/boto.cfg. Because tox


### PR DESCRIPTION
## Problem

Django 6.1 removed `fail_silently` from `BaseEmailBackend.__init__()`. `SESBackend` still forwards it at `django_ses/__init__.py:110`, so the backend cannot be used as a `MAILERS` entry:

```python
MAILERS = {"default": {"BACKEND": "django_ses.SESBackend"}}
```
```
InvalidMailer: MAILERS['default']: Unknown options 'fail_silently'.
```

`MailersHandler.create_connection()` calls `backend_class(alias=alias, **options)`. `SESBackend` passes `alias` through `**kwargs` *and* passes `fail_silently=` explicitly, and Django's base class raises `InvalidMailer` for unknown kwargs whenever `alias is not None`.

The legacy `EMAIL_BACKEND` path still works on 6.1, but emits a `RemovedInDjango70Warning` on every connection:

```
django_ses.SESBackend.__init__() does not support 'fail_silently'.
In Django 7.0, BaseEmailBackend will raise a TypeError for unknown keyword arguments.
```

`MAILERS` replaces `EMAIL_BACKEND` in Django 7.0, so this becomes a hard failure on both paths then.

## Fix

Set the attribute directly instead of forwarding it — which is what the Django 6.1 `BaseEmailBackend` docstring asks subclasses to do:

> `BaseEmailBackend.fail_silently` is deprecated. A subclass that supports `fail_silently` must set its own attribute.

```python
super(SESBackend, self).__init__(**kwargs)
self.fail_silently = fail_silently
```

No version guard is needed: on Django 3.2–6.0 the base class sets the same attribute to the same value, so this is a no-op there.

Also in this PR:

- `Framework :: Django :: 6.1` classifier
- `django61` tox env, and `61` in the CI matrix (6.1 supports Python 3.12–3.14, same exclusions as 6.0)
- Three tests in `tests/test_backend.py`, skipped below 6.1: instantiation as the default mailer, `OPTIONS` passthrough, and no `RemovedInDjango70Warning` on the legacy path
- A short `MAILERS` section in the README

The existing `django` dependency bound is already `<7`, so no dependency change is required.

## Verification

Ran `tests/` (everything except the LocalStack suite) locally against Django 4.2.30, 5.2.17, 6.0.8 and 6.1:

| Django | Result |
|---|---|
| 6.1 | 78 passed |
| 6.0.8 | 78 passed (3 skipped) |
| 5.2.17 | 78 passed (3 skipped) |
| 4.2.30 | 78 passed (3 skipped) |

Reverting just the two-line change in `django_ses/__init__.py` turns the three new tests into 2 errors + 1 failure on 6.1, so they do pin the fix rather than the surrounding setup.

One README note worth flagging for reviewers: `OPTIONS` values reach `SESBackend` verbatim, so `aws_region_endpoint` given there needs the `https://` scheme, while the `AWS_SES_REGION_ENDPOINT` setting does not (`conf.py` adds it in `AWS_SES_REGION_ENDPOINT_URL`). I documented the difference rather than changing the behaviour.
